### PR TITLE
Mover factorías de tests a extensiones y simplificar MockURLProtocol

### DIFF
--- a/Source/GIGLibrary/SwiftNetwork/Request.swift
+++ b/Source/GIGLibrary/SwiftNetwork/Request.swift
@@ -58,10 +58,12 @@ open class Request: Selfie {
 	
 	private var request: URLRequest?
 	private weak var task: URLSessionTask?
-    private let reachability: ReachabilityWrapper = ReachabilityWrapper.shared
+    private let reachability: ReachabilityInput
+    private let sessionConfiguration: URLSessionConfiguration?
+    private let session: URLSession?
     
     // TODO , para versiones futuras borrar este metodo
-    public convenience init(method: String, baseUrl: String, endpoint: String, headers: [String: String]? = nil, urlParams: [String: Any]? = nil, bodyParams: [String: Any]? = nil, timeout: TimeInterval? = nil, verbose: Bool = false) {
+    public convenience init(method: String, baseUrl: String, endpoint: String, headers: [String: String]? = nil, urlParams: [String: Any]? = nil, bodyParams: [String: Any]? = nil, timeout: TimeInterval? = nil, verbose: Bool = false, sessionConfiguration: URLSessionConfiguration? = nil, session: URLSession? = nil, reachability: ReachabilityInput = ReachabilityWrapper.shared) {
         self.init(
             method: method,
             baseUrl: baseUrl,
@@ -71,11 +73,14 @@ open class Request: Selfie {
             bodyParams: bodyParams,
             timeout: timeout,
             verbose: verbose,
-            standard: .gigigo
+            standard: .gigigo,
+            sessionConfiguration: sessionConfiguration,
+            session: session,
+            reachability: reachability
         )
     }
     
-    public convenience init(method: String, baseUrl: String, endpoint: String, headers: [String: String]? = nil, urlParams: [String: Any]? = nil, bodyParams: [String: Any]? = nil, timeout: TimeInterval? = nil, verbose: Bool = false, standard: StandardType = .gigigo) {
+    public convenience init(method: String, baseUrl: String, endpoint: String, headers: [String: String]? = nil, urlParams: [String: Any]? = nil, bodyParams: [String: Any]? = nil, timeout: TimeInterval? = nil, verbose: Bool = false, standard: StandardType = .gigigo, sessionConfiguration: URLSessionConfiguration? = nil, session: URLSession? = nil, reachability: ReachabilityInput = ReachabilityWrapper.shared) {
         self.init(method: method,
             baseUrl: baseUrl,
             endpoint: endpoint,
@@ -85,10 +90,13 @@ open class Request: Selfie {
             timeout: timeout,
             verbose: verbose,
             standard: standard,
-            logInfo: nil)
+            logInfo: nil,
+            sessionConfiguration: sessionConfiguration,
+            session: session,
+            reachability: reachability)
     }
 
-    public init(method: String, baseUrl: String, endpoint: String, headers: [String: String]? = nil, urlParams: [String: Any]? = nil, bodyParams: [String: Any]? = nil, timeout: TimeInterval? = nil, verbose: Bool = false, standard: StandardType = .gigigo, logInfo: RequestLogInfo? = nil) {
+    public init(method: String, baseUrl: String, endpoint: String, headers: [String: String]? = nil, urlParams: [String: Any]? = nil, bodyParams: [String: Any]? = nil, timeout: TimeInterval? = nil, verbose: Bool = false, standard: StandardType = .gigigo, logInfo: RequestLogInfo? = nil, sessionConfiguration: URLSessionConfiguration? = nil, session: URLSession? = nil, reachability: ReachabilityInput = ReachabilityWrapper.shared) {
         self.method = method
         self.baseURL = baseUrl
         self.endpoint = endpoint
@@ -99,9 +107,12 @@ open class Request: Selfie {
         self.verbose = verbose
         self.standardType = standard
         self.logInfo = logInfo
+        self.sessionConfiguration = sessionConfiguration
+        self.session = session
+        self.reachability = reachability
     }
 
-    public convenience init(method: HTTPMethod, completeURL: URL, headers: [String: String]? = nil, urlParams: [String: Any]? = nil, bodyParams: [String: Any]? = nil, timeout: TimeInterval? = nil, verbose: Bool = false, standard: StandardType = .gigigo) {
+    public convenience init(method: HTTPMethod, completeURL: URL, headers: [String: String]? = nil, urlParams: [String: Any]? = nil, bodyParams: [String: Any]? = nil, timeout: TimeInterval? = nil, verbose: Bool = false, standard: StandardType = .gigigo, sessionConfiguration: URLSessionConfiguration? = nil, session: URLSession? = nil, reachability: ReachabilityInput = ReachabilityWrapper.shared) {
         self.init(method: method,
             completeURL: completeURL, 
             headers: headers, 
@@ -110,10 +121,13 @@ open class Request: Selfie {
             timeout: timeout,
             verbose: verbose,
             standard: standard,
-            logInfo: nil)
+            logInfo: nil,
+            sessionConfiguration: sessionConfiguration,
+            session: session,
+            reachability: reachability)
     }
 
-    public init(method: HTTPMethod, completeURL: URL, headers: [String: String]? = nil, urlParams: [String: Any]? = nil, bodyParams: [String: Any]? = nil, timeout: TimeInterval? = nil, verbose: Bool = false, standard: StandardType = .gigigo, logInfo: RequestLogInfo? = nil) {
+    public init(method: HTTPMethod, completeURL: URL, headers: [String: String]? = nil, urlParams: [String: Any]? = nil, bodyParams: [String: Any]? = nil, timeout: TimeInterval? = nil, verbose: Bool = false, standard: StandardType = .gigigo, logInfo: RequestLogInfo? = nil, sessionConfiguration: URLSessionConfiguration? = nil, session: URLSession? = nil, reachability: ReachabilityInput = ReachabilityWrapper.shared) {
         self.method = method.rawValue
         self.completeURL = completeURL
         self.baseURL = completeURL.absoluteString
@@ -125,6 +139,9 @@ open class Request: Selfie {
         self.verbose = verbose
         self.standardType = standard
         self.logInfo = logInfo
+        self.sessionConfiguration = sessionConfiguration
+        self.session = session
+        self.reachability = reachability
     }
     
 	open func fetch(completionHandler: @escaping (Response) -> Void) {
@@ -138,13 +155,7 @@ open class Request: Selfie {
         self.logRequest()
 		self.cancel()
         
-        let configuration = URLSessionConfiguration.default
-        configuration.timeoutIntervalForResource = self.timeout
-        if #available(iOS 11, *) {
-            configuration.waitsForConnectivity = true
-        }
-        self.controlCache(config: configuration)
-        let session = URLSession(configuration: configuration, delegate: self as? URLSessionDelegate, delegateQueue: nil)
+        let session = self.configuredSession(applyCache: true)
         
 		self.task = session.dataTask(with: request) { data, urlResponse, error in
             
@@ -177,12 +188,7 @@ open class Request: Selfie {
         self.logRequest()
         self.cancel()
         
-        let configuration = URLSessionConfiguration.default
-        configuration.timeoutIntervalForResource = self.timeout
-        if #available(iOS 11, *) {
-            configuration.waitsForConnectivity = true
-        }
-        let session = URLSession(configuration: configuration, delegate: self as? URLSessionDelegate, delegateQueue: nil)
+        let session = self.configuredSession(applyCache: false)
 
         self.task = session.downloadTask(with: request) { location, response, error in
             guard let location = location else {
@@ -241,12 +247,7 @@ open class Request: Selfie {
         self.logRequest()
         self.cancel()
         
-        let configuration = URLSessionConfiguration.default
-        configuration.timeoutIntervalForResource = self.timeout
-        if #available(iOS 11, *) {
-            configuration.waitsForConnectivity = true
-        }
-        let session = URLSession(configuration: configuration, delegate: self as? URLSessionDelegate, delegateQueue: nil)
+        let session = self.configuredSession(applyCache: false)
         
         self.task = session.uploadTask(with: request, from: nil, completionHandler: { data, urlResponse, error in
             
@@ -279,6 +280,22 @@ open class Request: Selfie {
         default:
             break
         }
+    }
+
+    private func configuredSession(applyCache: Bool) -> URLSession {
+        if let session = self.session {
+            return session
+        }
+
+        let configuration = self.sessionConfiguration ?? URLSessionConfiguration.default
+        configuration.timeoutIntervalForResource = self.timeout
+        if #available(iOS 11, *) {
+            configuration.waitsForConnectivity = true
+        }
+        if applyCache {
+            self.controlCache(config: configuration)
+        }
+        return URLSession(configuration: configuration, delegate: self as? URLSessionDelegate, delegateQueue: nil)
     }
 	
     fileprivate func printLog(_ message: String, logInfo: RequestLogInfo) {

--- a/Source/GIGLibraryTests/SwiftNetwork/Fakes/ResponseFakes.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/Fakes/ResponseFakes.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension HTTPURLResponse {
+    static func fake(url: URL, statusCode: Int = 200, headers: [String: String]? = nil) -> HTTPURLResponse {
+        return HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: headers
+        )!
+    }
+}

--- a/Source/GIGLibraryTests/SwiftNetwork/Mocks/RequestMocks.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/Mocks/RequestMocks.swift
@@ -1,0 +1,68 @@
+import Foundation
+@testable import GIGLibrary
+
+final class MockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data?))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        guard let handler = MockURLProtocol.requestHandler else {
+            preconditionFailure("Request handler is missing.")
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            if let data = data {
+                client?.urlProtocol(self, didLoad: data)
+            }
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+extension MockURLProtocol {
+    static func respond(
+        statusCode: Int = 200,
+        headers: [String: String]? = nil,
+        data: Data? = nil,
+        capture: ((URLRequest) -> Void)? = nil
+    ) {
+        requestHandler = { request in
+            capture?(request)
+            let response = HTTPURLResponse.fake(url: request.url!, statusCode: statusCode, headers: headers)
+            return (response, data)
+        }
+    }
+}
+
+struct MockReachabilityProvider: ReachabilityInput {
+    let reachable: Bool
+
+    func isReachable() -> Bool {
+        return reachable
+    }
+
+    func isReachableViaWiFi() -> Bool {
+        return reachable
+    }
+}
+
+extension URLSessionConfiguration {
+    static func testConfiguration() -> URLSessionConfiguration {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return configuration
+    }
+}

--- a/Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift
@@ -34,7 +34,8 @@ struct RequestTests {
 
         // Then
         let urlRequest = try #require(capturedRequest)
-        let components = try #require(URLComponents(url: try #require(urlRequest.url), resolvingAgainstBaseURL: false))
+        let requestURL = try #require(urlRequest.url)
+        let components = try #require(URLComponents(url: requestURL, resolvingAgainstBaseURL: false))
         let queryItems = components.queryItems ?? []
         let queryDictionary = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
         let bodyObject = try #require(urlRequest.httpBody)

--- a/Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift
@@ -10,9 +10,9 @@ struct RequestTests {
         let configuration = URLSessionConfiguration.testConfiguration()
         var capturedRequest: URLRequest?
 
-        MockURLProtocol.respond { request in
+        MockURLProtocol.respond(capture: { request in
             capturedRequest = request
-        }
+        })
 
         let request = Request(
             method: HTTPMethod.post.rawValue,
@@ -57,9 +57,9 @@ struct RequestTests {
         let configuration = URLSessionConfiguration.testConfiguration()
         var capturedRequest: URLRequest?
 
-        MockURLProtocol.respond { request in
+        MockURLProtocol.respond(capture: { request in
             capturedRequest = request
-        }
+        })
 
         let request = Request(
             method: HTTPMethod.post.rawValue,
@@ -99,9 +99,9 @@ struct RequestTests {
         let configuration = URLSessionConfiguration.testConfiguration()
         var didReceiveRequest = false
 
-        MockURLProtocol.respond { _ in
+        MockURLProtocol.respond(capture: { _ in
             didReceiveRequest = true
-        }
+        })
 
         let request = Request(
             method: HTTPMethod.get.rawValue,

--- a/Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Testing
+@testable import GIGLibrary
+
+@Suite
+struct RequestTests {
+    @Test("Given a POST request with body params, when fetch is called, then URL, headers, and body are built correctly")
+    func fetchBuildsRequestWithBodyParams() async throws {
+        // Given
+        let configuration = URLSessionConfiguration.testConfiguration()
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.respond { request in
+            capturedRequest = request
+        }
+
+        let request = Request(
+            method: HTTPMethod.post.rawValue,
+            baseUrl: "https://example.com/api",
+            endpoint: "/v1/test",
+            headers: ["Accept": "application/json"],
+            urlParams: ["foo": "bar", "page": 2],
+            bodyParams: ["name": "Taylor", "count": 3],
+            sessionConfiguration: configuration,
+            reachability: MockReachabilityProvider(reachable: true)
+        )
+
+        // When
+        _ = await withCheckedContinuation { continuation in
+            request.fetch { _ in
+                continuation.resume(returning: ())
+            }
+        }
+
+        // Then
+        let urlRequest = try #require(capturedRequest)
+        let components = try #require(URLComponents(url: try #require(urlRequest.url), resolvingAgainstBaseURL: false))
+        let queryItems = components.queryItems ?? []
+        let queryDictionary = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
+        let bodyObject = try #require(urlRequest.httpBody)
+        let bodyJson = try JSONSerialization.jsonObject(with: bodyObject) as? [String: Any]
+
+        #expect(urlRequest.httpMethod == HTTPMethod.post.rawValue)
+        #expect(urlRequest.value(forHTTPHeaderField: "Accept") == "application/json")
+        #expect(urlRequest.value(forHTTPHeaderField: "Content-Type") == "application/json")
+        #expect(components.host == "example.com")
+        #expect(components.path == "/api/v1/test")
+        #expect(queryDictionary["foo"] == "bar")
+        #expect(queryDictionary["page"] == "2")
+        #expect(bodyJson?["name"] as? String == "Taylor")
+        #expect(bodyJson?["count"] as? Int == 3)
+    }
+
+    @Test("Given a POST request with a body params array, when fetch is called, then body and headers are built correctly")
+    func fetchBuildsRequestWithBodyParamsArray() async throws {
+        // Given
+        let configuration = URLSessionConfiguration.testConfiguration()
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.respond { request in
+            capturedRequest = request
+        }
+
+        let request = Request(
+            method: HTTPMethod.post.rawValue,
+            baseUrl: "https://example.com",
+            endpoint: "/items",
+            bodyParams: nil,
+            timeout: nil,
+            verbose: false,
+            standard: .gigigo,
+            sessionConfiguration: configuration,
+            reachability: MockReachabilityProvider(reachable: true)
+        )
+        request.bodyParamsArray = [["id": 1], ["id": 2]]
+
+        // When
+        _ = await withCheckedContinuation { continuation in
+            request.fetch { _ in
+                continuation.resume(returning: ())
+            }
+        }
+
+        // Then
+        let urlRequest = try #require(capturedRequest)
+        let bodyObject = try #require(urlRequest.httpBody)
+        let bodyJson = try JSONSerialization.jsonObject(with: bodyObject) as? [[String: Any]]
+
+        #expect(urlRequest.httpMethod == HTTPMethod.post.rawValue)
+        #expect(urlRequest.value(forHTTPHeaderField: "Content-Type") == "application/json")
+        #expect(bodyJson?.count == 2)
+        #expect(bodyJson?.first?["id"] as? Int == 1)
+        #expect(bodyJson?.last?["id"] as? Int == 2)
+    }
+
+    @Test("Given reachability is offline, when fetch is called, then it returns a no-internet response")
+    func fetchReturnsNoInternetWhenOffline() async {
+        // Given
+        let configuration = URLSessionConfiguration.testConfiguration()
+        var didReceiveRequest = false
+
+        MockURLProtocol.respond { _ in
+            didReceiveRequest = true
+        }
+
+        let request = Request(
+            method: HTTPMethod.get.rawValue,
+            baseUrl: "https://example.com",
+            endpoint: "/offline",
+            sessionConfiguration: configuration,
+            reachability: MockReachabilityProvider(reachable: false)
+        )
+
+        // When
+        let response = await withCheckedContinuation { continuation in
+            request.fetch { response in
+                continuation.resume(returning: response)
+            }
+        }
+
+        // Then
+        #expect(response.status == .noInternet)
+        #expect(didReceiveRequest == false)
+    }
+}


### PR DESCRIPTION
### Motivation
- Centralizar la creación de la `URLSession` de pruebas en una API clara para facilitar el setup de tests de red.
- Reducir el boilerplate al configurar respuestas de red en tests mediante un helper más simple para el `MockURLProtocol`.
- Permitir la inyección de `URLSessionConfiguration`, `URLSession` y un proveedor de reachability en `Request` para facilitar pruebas y mocks.

### Description
- Added `URLSessionConfiguration.testConfiguration()` and `HTTPURLResponse.fake(...)` as type extensions to provide reusable test factories.
- Implemented `MockURLProtocol.respond(...)` to set a simple response/capture closure and kept the underlying `requestHandler` for flexibility.
- Added `MockReachabilityProvider` and test files under `Source/GIGLibraryTests/SwiftNetwork/` including `RequestTests.swift` with three test cases exercising request building, array body handling, and offline behavior.
- Updated `Request` to accept `sessionConfiguration`, `session`, and `reachability` parameters and introduced the private helper `configuredSession(applyCache:)` to centralize session creation.

### Testing
- No automated tests were executed as part of this change (not run in CI).
- Unit test files were added in `Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift` containing three tests verifying request building, body array serialization, and offline handling.
- Tests are wired to use `URLSessionConfiguration.testConfiguration()` and `MockURLProtocol.respond(...)` but have not been run automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957af2980c8832c87190dd0bcfd1c20)