### PR TITLE
Añadir test para merge de query params en `completeURL` y evitar concatenar `endpoint`

### DIFF
--- a/Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift
@@ -123,4 +123,49 @@ struct RequestTests {
         #expect(response.status == .noInternet)
         #expect(didReceiveRequest == false)
     }
+
+    @Test("Given a complete URL with query params, when fetch is called, then it merges existing and new params without appending the endpoint")
+    func fetchBuildsRequestWithCompleteURLAndUrlParams() async throws {
+        // Given
+        let configuration = URLSessionConfiguration.testConfiguration()
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.respond { request in
+            capturedRequest = request
+        }
+
+        let completeURL = try #require(URL(string: "https://example.com/api/resource?existing=one&token=abc"))
+        let request = Request(
+            method: .get,
+            completeURL: completeURL,
+            headers: nil,
+            urlParams: ["foo": "bar", "page": 2],
+            bodyParams: nil,
+            sessionConfiguration: configuration,
+            reachability: MockReachabilityProvider(reachable: true)
+        )
+        request.endpoint = "/should-not-append"
+
+        // When
+        _ = await withCheckedContinuation { continuation in
+            request.fetch { _ in
+                continuation.resume(returning: ())
+            }
+        }
+
+        // Then
+        let urlRequest = try #require(capturedRequest)
+        let requestURL = try #require(urlRequest.url)
+        let components = try #require(URLComponents(url: requestURL, resolvingAgainstBaseURL: false))
+        let queryItems = components.queryItems ?? []
+        let queryValue = { (name: String) in
+            queryItems.first(where: { $0.name == name })?.value
+        }
+
+        #expect(components.path == "/api/resource")
+        #expect(queryValue("existing") == "one")
+        #expect(queryValue("token") == "abc")
+        #expect(queryValue("foo") == "bar")
+        #expect(queryValue("page") == "2")
+    }
 }


### PR DESCRIPTION
### Motivation
- Ensure that when a `Request` is created with a `completeURL` that already contains query parameters, additional `urlParams` are merged rather than replacing them.
- Prevent accidental concatenation of `endpoint` onto a provided `completeURL` to avoid generating incorrect request paths.
- Add a regression test to capture and assert `URLComponents` behavior for `completeURL` handling.

### Description
- Added a new unit test `fetchBuildsRequestWithCompleteURLAndUrlParams` in `Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift` that constructs a `Request` with a `completeURL` containing query params and additional `urlParams`.
- The test captures the outgoing `URLRequest` via `MockURLProtocol.respond` and inspects `URLComponents` to assert both existing and new query items are present.
- The test also sets `request.endpoint` to ensure it is not appended when `completeURL` is used by asserting the resulting `components.path`.

### Testing
- The test uses `URLSessionConfiguration.testConfiguration()` and `MockReachabilityProvider` to run in isolation if executed by CI or locally.
- The modification only adds a test and does not change production code logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966763e096c832cbbb85f765d79d9a4)