### PR TITLE
Agregar prueba: GET con bodyParams y headers vacíos no añade body ni Content-Type

### DIFF
--- a/Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift
@@ -94,6 +94,41 @@ struct RequestTests {
         #expect(bodyJson?.last?["id"] as? Int == 2)
     }
 
+    @Test("Given a GET request with empty body params and headers, when fetch is called, then it does not add a body or Content-Type header")
+    func fetchDoesNotSetBodyOrContentTypeForEmptyGet() async throws {
+        // Given
+        let configuration = URLSessionConfiguration.testConfiguration()
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.respond { request in
+            capturedRequest = request
+        }
+
+        let request = Request.testRequest(
+            method: HTTPMethod.get.rawValue,
+            baseUrl: "https://example.com",
+            endpoint: "/v1/empty",
+            headers: [:],
+            urlParams: nil,
+            bodyParams: [:],
+            sessionConfiguration: configuration,
+            reachability: MockReachabilityProvider(reachable: true)
+        )
+
+        // When
+        _ = await withCheckedContinuation { continuation in
+            request.fetch { _ in
+                continuation.resume(returning: ())
+            }
+        }
+
+        // Then
+        let urlRequest = try #require(capturedRequest)
+
+        #expect(urlRequest.httpBody == nil)
+        #expect(urlRequest.value(forHTTPHeaderField: "Content-Type") == nil)
+    }
+
     @Test("Given reachability is offline, when fetch is called, then it returns a no-internet response")
     func fetchReturnsNoInternetWhenOffline() async {
         // Given


### PR DESCRIPTION
### Motivation
- Ensure GET requests do not include an HTTP body or a `Content-Type` header when both `bodyParams` and `headers` are empty to avoid sending unnecessary payload or headers.
- Prevent regressions in `Request` building logic for idempotent methods like GET.

### Description
- Added a new test `fetchDoesNotSetBodyOrContentTypeForEmptyGet` in `Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift` that builds a `Request` via `Request.testRequest` with `method: HTTPMethod.get.rawValue`, `headers: [:]` and `bodyParams: [:]`.
- The test captures the produced `URLRequest` using `MockURLProtocol.respond`, calls `request.fetch` and asserts that `urlRequest.httpBody == nil` and `urlRequest.value(forHTTPHeaderField: "Content-Type") == nil`.

### Testing
- No automated tests were executed as part of this change (tests were added but not run).
- The change only adds a unit test and does not modify production code behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966799ad250832c939700d19d5a9571)