### PR TITLE
Añadir test para preservar `Content-Type` personalizado

### DIFF
--- a/Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift
@@ -94,6 +94,41 @@ struct RequestTests {
         #expect(bodyJson?.last?["id"] as? Int == 2)
     }
 
+    @Test("Given a POST request with a custom Content-Type header, when fetch is called, then it keeps the custom value and does not inject application/json")
+    func fetchKeepsCustomContentTypeHeader() async throws {
+        // Given
+        let configuration = URLSessionConfiguration.testConfiguration()
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.respond { request in
+            capturedRequest = request
+        }
+
+        let request = Request.testRequest(
+            method: HTTPMethod.post.rawValue,
+            baseUrl: "https://example.com",
+            endpoint: "/custom-content-type",
+            headers: ["Content-Type": "application/custom"],
+            urlParams: nil,
+            bodyParams: ["status": "ok"],
+            sessionConfiguration: configuration,
+            reachability: MockReachabilityProvider(reachable: true)
+        )
+
+        // When
+        _ = await withCheckedContinuation { continuation in
+            request.fetch { _ in
+                continuation.resume(returning: ())
+            }
+        }
+
+        // Then
+        let urlRequest = try #require(capturedRequest)
+
+        #expect(urlRequest.value(forHTTPHeaderField: "Content-Type") == "application/custom")
+        #expect(urlRequest.value(forHTTPHeaderField: "Content-Type") != "application/json")
+    }
+
     @Test("Given a GET request with empty body params and headers, when fetch is called, then it does not add a body or Content-Type header")
     func fetchDoesNotSetBodyOrContentTypeForEmptyGet() async throws {
         // Given


### PR DESCRIPTION
### Motivation
- Evitar que la lógica de construcción de requests sobrescriba un `Content-Type` ya provisto por el usuario con `application/json` en peticiones POST.
- Verificar que cuando se pasa `Content-Type: application/custom` en `headers`, ese valor se mantiene intacto durante el `fetch`.

### Description
- Se añade el test `fetchKeepsCustomContentTypeHeader` en `Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift` que crea un `Request` POST con `headers: ["Content-Type": "application/custom"]` y `bodyParams`.
- El test utiliza `MockURLProtocol.respond` para capturar la `URLRequest` enviada y asserta que `value(forHTTPHeaderField: "Content-Type")` sea `application/custom` y no `application/json`.
- No se realizan cambios en el código de producción; solo se agrega el caso de prueba para cubrir este comportamiento.

### Testing
- No se ejecutaron tests automatizados durante este cambio.
- El nuevo test fue agregado al suite de tests unitarios en `Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift` pero no se reportó ejecución ni resultado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966802e6f24832c836529182fc40ae4)