### PR TITLE
Add download-to-file tests for `fetch(withDownloadUrlFile:)`

### DIFF
--- a/Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift
@@ -295,4 +295,76 @@ struct RequestTests {
         #expect(bodyString.contains("1"))
         #expect(bodyString.contains("--\(boundary)"))
     }
+
+    @Test("Given a download request with a temporary destination, when fetch is called, then it saves the file and returns status code 200")
+    func fetchDownloadSavesFileToTemporaryDirectory() async throws {
+        // Given
+        let configuration = URLSessionConfiguration.testConfiguration()
+        let fileData = Data("downloaded content".utf8)
+        let destinationURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+
+        defer {
+            try? FileManager.default.removeItem(at: destinationURL)
+        }
+
+        MockURLProtocol.respond(data: fileData)
+
+        let request = Request.testRequest(
+            method: HTTPMethod.get.rawValue,
+            baseUrl: "https://example.com",
+            endpoint: "/download",
+            sessionConfiguration: configuration,
+            reachability: MockReachabilityProvider(reachable: true)
+        )
+
+        // When
+        let response = await withCheckedContinuation { continuation in
+            request.fetch(withDownloadUrlFile: destinationURL) { response in
+                continuation.resume(returning: response)
+            }
+        }
+
+        // Then
+        #expect(FileManager.default.fileExists(atPath: destinationURL.path))
+        let savedData = try #require(Data(contentsOf: destinationURL))
+        #expect(savedData == fileData)
+        #expect(response.statusCode == 200)
+    }
+
+    @Test("Given a download request with an existing destination file, when fetch is called, then it overwrites the file")
+    func fetchDownloadOverwritesExistingFile() async throws {
+        // Given
+        let configuration = URLSessionConfiguration.testConfiguration()
+        let originalData = Data("original content".utf8)
+        let updatedData = Data("updated content".utf8)
+        let destinationURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+
+        try originalData.write(to: destinationURL)
+        defer {
+            try? FileManager.default.removeItem(at: destinationURL)
+        }
+
+        MockURLProtocol.respond(data: updatedData)
+
+        let request = Request.testRequest(
+            method: HTTPMethod.get.rawValue,
+            baseUrl: "https://example.com",
+            endpoint: "/download-overwrite",
+            sessionConfiguration: configuration,
+            reachability: MockReachabilityProvider(reachable: true)
+        )
+
+        // When
+        let response = await withCheckedContinuation { continuation in
+            request.fetch(withDownloadUrlFile: destinationURL) { response in
+                continuation.resume(returning: response)
+            }
+        }
+
+        // Then
+        #expect(FileManager.default.fileExists(atPath: destinationURL.path))
+        let savedData = try #require(Data(contentsOf: destinationURL))
+        #expect(savedData == updatedData)
+        #expect(response.statusCode == 200)
+    }
 }

--- a/Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift
@@ -326,7 +326,7 @@ struct RequestTests {
 
         // Then
         #expect(FileManager.default.fileExists(atPath: destinationURL.path))
-        let savedData = try #require(Data(contentsOf: destinationURL))
+        let savedData = try Data(contentsOf: destinationURL)
         #expect(savedData == fileData)
         #expect(response.statusCode == 200)
     }
@@ -363,7 +363,7 @@ struct RequestTests {
 
         // Then
         #expect(FileManager.default.fileExists(atPath: destinationURL.path))
-        let savedData = try #require(Data(contentsOf: destinationURL))
+        let savedData = try Data(contentsOf: destinationURL)
         #expect(savedData == updatedData)
         #expect(response.statusCode == 200)
     }


### PR DESCRIPTION
### Motivation
- Add unit tests to verify download-to-file behavior of `fetch(withDownloadUrlFile:)` when writing to a temporary destination using `FileManager.default.temporaryDirectory`.
- Ensure the download handling correctly saves contents returned by the network layer simulated by `MockURLProtocol`.
- Validate overwrite behavior when a destination file already exists to prevent unexpected file retention.

### Description
- Added two tests in `Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift` that exercise `fetch(withDownloadUrlFile:)`: one that saves a downloaded file to a temporary path and one that overwrites an existing file.
- Tests use `MockURLProtocol.respond(data:)` to simulate server responses and `Request.testRequest(...)` with `URLSessionConfiguration.testConfiguration()` to route requests to the mock protocol.
- Each test verifies the destination file exists and its contents match the mocked `Data`, and asserts `response.statusCode == 200`.
- Clean up is performed with `try? FileManager.default.removeItem(at:)` in `defer` blocks to remove temporary files after each test.

### Testing
- No automated test suite was executed as part of this change, so the new tests have been added but not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69668766198c832cb66c0f7339405292)