### PR TITLE
Agregar tests para parseo de `Response` con JSON status

### DIFF
--- a/Source/GIGLibraryTests/SwiftNetwork/ResponseTests.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/ResponseTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+@testable import GIGLibrary
+
+@Suite(.serialized)
+struct ResponseTests {
+    private func makeJSONResponse(body: [String: Any]) throws -> Response {
+        let data = try JSONSerialization.data(withJSONObject: body, options: [])
+        let url = try #require(URL(string: "https://example.com"))
+        let response = HTTPURLResponse.fake(
+            url: url,
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"]
+        )
+        return Response(data: data, response: response, error: nil, standardType: .gigigo)
+    }
+
+    @Test("Given JSON status true with data, when Response parses, then it is success and data points to the data node")
+    func responseParsesSuccessWithDataNode() throws {
+        // Given
+        let body: [String: Any] = [
+            "status": true,
+            "data": [
+                "id": 101,
+                "name": "Sample"
+            ]
+        ]
+
+        // When
+        let response = try makeJSONResponse(body: body)
+
+        // Then
+        #expect(response.status == .success)
+        #expect(response.data?.toDictionary()?["id"] as? Int == 101)
+        #expect(response.data?.toDictionary()?["name"] as? String == "Sample")
+    }
+
+    @Test("Given JSON status OK with data, when Response parses, then it is success")
+    func responseParsesSuccessWithOkStatusString() throws {
+        // Given
+        let body: [String: Any] = [
+            "status": "OK",
+            "data": [
+                "message": "Done"
+            ]
+        ]
+
+        // When
+        let response = try makeJSONResponse(body: body)
+
+        // Then
+        #expect(response.status == .success)
+        #expect(response.data?.toDictionary()?["message"] as? String == "Done")
+    }
+
+    @Test("Given JSON error code and message, when Response parses, then it creates an API error with expected domain")
+    func responseParsesApiErrorWithDomain() throws {
+        // Given
+        let body: [String: Any] = [
+            "error": [
+                "code": 15000,
+                "message": "Invalid token"
+            ]
+        ]
+
+        // When
+        let response = try makeJSONResponse(body: body)
+
+        // Then
+        #expect(response.status == .apiError)
+        #expect(response.error?.domain == kGIGNetworkErrorDomain)
+        #expect(response.error?.code == 15000)
+        #expect(response.error?.userInfo[kGIGNetworkErrorMessage] as? String == "Invalid token")
+    }
+}


### PR DESCRIPTION
### Motivation
- Garantizar que `Response` parsea cuerpos JSON con `Content-Type: application/json` según el estándar `gigigo`.
- Verificar que `status` booleano y string (`"OK"`) se consideran `ResponseStatus.success`.
- Asegurar que los errores con `error.code` y `error.message` generan un `NSError` con dominio `kGIGNetworkErrorDomain`.
- Comprobar que códigos en `10000...20000` se mapean a `ResponseStatus.apiError`.

### Description
- Se añadió el archivo de tests `Source/GIGLibraryTests/SwiftNetwork/ResponseTests.swift` con la suite `ResponseTests`.
- Se incorporó el helper `makeJSONResponse` que crea un `Response` usando `Response(data:response:error:standardType:)` y un `HTTPURLResponse.fake` con `Content-Type: application/json`.
- Se añadieron tres tests que cubren: `status: true` con `data`, `status: "OK"` y `error` con `code/message`.
- Los assertions verifican `response.status`, el contenido de `response.data` y que `response.error` tenga `kGIGNetworkErrorDomain` y `kGIGNetworkErrorMessage` en `userInfo`.

### Testing
- No se ejecutaron tests automatizados como parte de esta PR.
- Se añadieron tests automatizados en `Source/GIGLibraryTests/SwiftNetwork/ResponseTests.swift` que pueden ejecutarse con el runner del proyecto.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696691679ff0832c882be6c885355e95)