### PR TITLE
Añadir tests para mapeo de NSError a ResponseStatus

### DIFF
--- a/Source/GIGLibraryTests/SwiftNetwork/ResponseTests.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/ResponseTests.swift
@@ -92,4 +92,26 @@ struct ResponseTests {
         #expect(response.data?.toDictionary()?["message"] as? String == "Hello")
         #expect(response.data?.toDictionary()?["count"] as? Int == 2)
     }
+
+    @Test("Given NSError codes without URL response, when Response parses, then it maps to expected ResponseStatus")
+    func responseMapsNSErrorCodesToResponseStatus() {
+        // Given
+        let cases: [(Int, ResponseStatus)] = [
+            (401, .sessionExpired),
+            (-1001, .timeout),
+            (-1009, .noInternet),
+            (-1202, .untrustedCertificate),
+            (42, .unknownError)
+        ]
+
+        for (code, expectedStatus) in cases {
+            let error = NSError(domain: NSURLErrorDomain, code: code, message: "Test error")
+
+            // When
+            let response = Response(data: nil, response: nil, error: error)
+
+            // Then
+            #expect(response.status == expectedStatus)
+        }
+    }
 }


### PR DESCRIPTION
### Motivation
- Detectar y validar el mapeo de errores de red en `Response` cuando no hay `URLResponse`.
- Cubrir casos específicos de `NSError` que deben mapearse a `.sessionExpired`, `.timeout`, `.noInternet` y `.untrustedCertificate`.
- Añadir un caso fuera de rango para asegurar que se devuelve `.unknownError`.

### Description
- Added a new test `responseMapsNSErrorCodesToResponseStatus` in `Source/GIGLibraryTests/SwiftNetwork/ResponseTests.swift`.
- The test constructs `Response(data: nil, response: nil, error:)` with `NSError` codes `401`, `-1001`, `-1009`, `-1202`, and `42`.
- The test asserts that `Response.status` is `.sessionExpired`, `.timeout`, `.noInternet`, `.untrustedCertificate`, and `.unknownError` respectively.

### Testing
- No se ejecutaron pruebas automatizadas como parte de este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696699e552a0832cad2dbca5e694b896)