### PR TITLE
Añadir test de descarga offline que verifica no-internet y ausencia de escritura

### DIFF
--- a/Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift
@@ -194,6 +194,38 @@ struct RequestTests {
         #expect(didReceiveRequest == false)
     }
 
+    @Test("Given a download request while offline, when fetch is called, then it does not write a file and returns no-internet")
+    func fetchDownloadReturnsNoInternetWhenOffline() async {
+        // Given
+        let configuration = URLSessionConfiguration.testConfiguration()
+        let destinationURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        var didReceiveRequest = false
+
+        MockURLProtocol.respond { _ in
+            didReceiveRequest = true
+        }
+
+        let request = Request.testRequest(
+            method: HTTPMethod.get.rawValue,
+            baseUrl: "https://example.com",
+            endpoint: "/offline-download",
+            sessionConfiguration: configuration,
+            reachability: MockReachabilityProvider(reachable: false)
+        )
+
+        // When
+        let response = await withCheckedContinuation { continuation in
+            request.fetch(withDownloadUrlFile: destinationURL) { response in
+                continuation.resume(returning: response)
+            }
+        }
+
+        // Then
+        #expect(response.status == .noInternet)
+        #expect(FileManager.default.fileExists(atPath: destinationURL.path) == false)
+        #expect(didReceiveRequest == false)
+    }
+
     @Test("Given a complete URL with query params, when fetch is called, then it merges existing and new params without appending the endpoint")
     func fetchBuildsRequestWithCompleteURLAndUrlParams() async throws {
         // Given


### PR DESCRIPTION
### Motivation
- Añadir cobertura para el caso de descarga cuando no hay conectividad para asegurar que la operación devuelve `.noInternet`, no escribe el fichero destino y no invoca el handler de red.

### Description
- Se añadió el test `fetchDownloadReturnsNoInternetWhenOffline` en `Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift` que crea un `Request` con `MockReachabilityProvider(reachable: false)`, llama a `fetch(withDownloadUrlFile:)` con un destino temporal y verifica que `response.status == .noInternet`, que el fichero no existe en el destino y que `MockURLProtocol` no recibió la petición.

### Testing
- No se ejecutaron pruebas automatizadas sobre este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968eb364154832c816c6939f693f733)