### PR TITLE
Agregar tests de Response para cuerpos JSON vacíos (204 y 200)

### DIFF
--- a/Source/GIGLibraryTests/SwiftNetwork/ResponseTests.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/ResponseTests.swift
@@ -114,4 +114,42 @@ struct ResponseTests {
             #expect(response.status == expectedStatus)
         }
     }
+
+    @Test("Given a 204 JSON response without body, when Response parses, then it is success with no data expected")
+    func responseParsesSuccessWithNoContentBody() throws {
+        // Given
+        let url = try #require(URL(string: "https://example.com"))
+        let httpResponse = HTTPURLResponse.fake(
+            url: url,
+            statusCode: 204,
+            headers: ["Content-Type": "application/json"]
+        )
+
+        // When
+        let response = Response(data: nil, response: httpResponse, error: nil)
+
+        // Then
+        #expect(response.status == .success)
+        #expect(response.statusCode == 204)
+        #expect(response.data == nil)
+    }
+
+    @Test("Given a 200 JSON response with empty body, when Response parses, then it is success with no data expected")
+    func responseParsesSuccessWithEmptyBody() throws {
+        // Given
+        let url = try #require(URL(string: "https://example.com"))
+        let httpResponse = HTTPURLResponse.fake(
+            url: url,
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"]
+        )
+
+        // When
+        let response = Response(data: Data(), response: httpResponse, error: nil)
+
+        // Then
+        #expect(response.status == .success)
+        #expect(response.statusCode == 200)
+        #expect(response.data == nil)
+    }
 }


### PR DESCRIPTION
### Motivation
- Añadir cobertura para los casos donde la respuesta tiene `Content-Type: application/json` pero no contiene payload útil (HTTP 204 con `data: nil` y HTTP 200 con `data: Data()`), asegurando que `Response` marca éxito y no asigna `data`.

### Description
- Se añadieron dos tests en `Source/GIGLibraryTests/SwiftNetwork/ResponseTests.swift` que crean un `HTTPURLResponse.fake` con `Content-Type: application/json` y status codes `204` y `200` respectivamente.
- Cada test construye la instancia `Response` con `data: nil` (para 204) y `data: Data()` (para 200) y verifica `response.status == .success`, el `response.statusCode` esperado y que `response.data == nil`.
- Las descripciones de los tests documentan explícitamente que no se espera `data` en estos casos.

### Testing
- No se ejecutaron pruebas automatizadas durante este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968f2b52590832c9fd7461998fd79e4)