### PR TITLE
Unificar extensión de MockURLProtocol y agregar FixtureLoader y fixtures

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,9 @@ let package = Package(
 			dependencies: []),
 		.testTarget(
 			name: "GIGLibraryTests",
-			dependencies: ["GIGLibrary"])
+			dependencies: ["GIGLibrary"],
+			resources: [
+				.process("SwiftNetwork/Fakes/Fixtures")
+			])
 	]
 )

--- a/Source/GIGLibraryTests/SwiftNetwork/Fakes/FixtureLoader.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/Fakes/FixtureLoader.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum FixtureLoaderError: Error {
+    case missingFixture(String)
+}
+
+enum FixtureLoader {
+    static func data(named name: String, bundle: Bundle = .module) throws -> Data {
+        let resourceName = name.hasSuffix(".json") ? String(name.dropLast(5)) : name
+        guard let url = bundle.url(forResource: resourceName, withExtension: "json") else {
+            throw FixtureLoaderError.missingFixture(resourceName)
+        }
+        return try Data(contentsOf: url)
+    }
+}

--- a/Source/GIGLibraryTests/SwiftNetwork/Fakes/Fixtures/api_error.json
+++ b/Source/GIGLibraryTests/SwiftNetwork/Fakes/Fixtures/api_error.json
@@ -1,0 +1,7 @@
+{
+  "status": false,
+  "error": {
+    "code": 15000,
+    "message": "Invalid token"
+  }
+}

--- a/Source/GIGLibraryTests/SwiftNetwork/Fakes/Fixtures/basic_success.json
+++ b/Source/GIGLibraryTests/SwiftNetwork/Fakes/Fixtures/basic_success.json
@@ -1,0 +1,4 @@
+{
+  "message": "Hello",
+  "count": 2
+}

--- a/Source/GIGLibraryTests/SwiftNetwork/Fakes/Fixtures/success.json
+++ b/Source/GIGLibraryTests/SwiftNetwork/Fakes/Fixtures/success.json
@@ -1,0 +1,7 @@
+{
+  "status": true,
+  "data": {
+    "id": 101,
+    "name": "Sample"
+  }
+}

--- a/Source/GIGLibraryTests/SwiftNetwork/Mocks/RequestMocks.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/Mocks/RequestMocks.swift
@@ -58,6 +58,18 @@ extension MockURLProtocol {
         return data
     }
 
+    private static func prepareCapturedRequest(
+        _ request: URLRequest,
+        _ capture: ((URLRequest) -> Void)?
+    ) -> URLRequest {
+        var capturedRequest = request
+        if capturedRequest.httpBody == nil, let body = requestBody(from: request) {
+            capturedRequest.httpBody = body
+        }
+        capture?(capturedRequest)
+        return capturedRequest
+    }
+
     static func respond(
         statusCode: Int = 200,
         headers: [String: String]? = nil,
@@ -65,14 +77,78 @@ extension MockURLProtocol {
         _ capture: ((URLRequest) -> Void)? = nil
     ) {
         requestHandler = { request in
-            var capturedRequest = request
-            if capturedRequest.httpBody == nil, let body = requestBody(from: request) {
-                capturedRequest.httpBody = body
-            }
-            capture?(capturedRequest)
+            _ = prepareCapturedRequest(request, capture)
             let response = HTTPURLResponse.fake(url: request.url!, statusCode: statusCode, headers: headers)
             return (response, data)
         }
+    }
+
+    static func respond(
+        fixture name: String,
+        statusCode: Int = 200,
+        headers: [String: String]? = ["Content-Type": "application/json"],
+        _ capture: ((URLRequest) -> Void)? = nil
+    ) {
+        requestHandler = { request in
+            _ = prepareCapturedRequest(request, capture)
+            let data = try FixtureLoader.data(named: name)
+            let response = HTTPURLResponse.fake(url: request.url!, statusCode: statusCode, headers: headers)
+            return (response, data)
+        }
+    }
+
+    static func respond(
+        routes: [FixtureRoute],
+        _ capture: ((URLRequest) -> Void)? = nil
+    ) {
+        requestHandler = { request in
+            _ = prepareCapturedRequest(request, capture)
+
+            guard let url = request.url else {
+                throw FixtureRouteError.invalidRequest
+            }
+
+            let path = url.path
+            let method = request.httpMethod ?? ""
+
+            guard let route = routes.first(where: { route in
+                let methodMatches = route.method.map { $0.caseInsensitiveCompare(method) == .orderedSame } ?? true
+                return methodMatches && route.path == path
+            }) else {
+                throw FixtureRouteError.unmatchedRoute(method: method, path: path)
+            }
+
+            let data = try FixtureLoader.data(named: route.fixture)
+            let response = HTTPURLResponse.fake(url: url, statusCode: route.statusCode, headers: route.headers)
+            return (response, data)
+        }
+    }
+}
+
+enum FixtureRouteError: Error {
+    case invalidRequest
+    case unmatchedRoute(method: String, path: String)
+}
+
+struct FixtureRoute {
+    let method: String?
+    let path: String
+    let fixture: String
+    let statusCode: Int
+    let headers: [String: String]?
+
+    init(
+        method: String? = nil,
+        path: String,
+        fixture: String,
+        statusCode: Int = 200,
+        headers: [String: String]? = ["Content-Type": "application/json"]
+    ) {
+        self.method = method
+        self.path = path
+        self.fixture = fixture
+        self.statusCode = statusCode
+        self.headers = headers
     }
 }
 

--- a/Source/GIGLibraryTests/SwiftNetwork/Mocks/RequestMocks.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/Mocks/RequestMocks.swift
@@ -109,7 +109,7 @@ extension MockURLProtocol {
             }
 
             let path = url.path
-            let method = request.httpMethod ?? ""
+            let method = request.httpMethod ?? HTTPMethod.get.rawValue
 
             guard let route = routes.first(where: { route in
                 let methodMatches = route.method.map { $0.caseInsensitiveCompare(method) == .orderedSame } ?? true


### PR DESCRIPTION
### Motivation
- Consolidar los helpers de stubbing de red en una única extensión de `MockURLProtocol` para reducir duplicación y mejorar claridad.
- Proveer un loader de fixtures y los ficheros JSON necesarios para facilitar respuestas basadas en fixtures en tests.

### Description
- Unificado todos los métodos `respond(...)` dentro de una sola `extension MockURLProtocol` y extraída la lógica común a la función privada `prepareCapturedRequest` para manejar el body y la captura del `URLRequest`.
- Añadido `FixtureLoader.swift` con `FixtureLoader.data(named:bundle:)` para cargar recursos JSON desde el paquete y se añadieron los fixtures `api_error.json`, `basic_success.json` y `success.json` en `SwiftNetwork/Fakes/Fixtures`.
- Añadido el soporte de rutas con `FixtureRoute` y `FixtureRouteError` y el helper `respond(routes:)` que selecciona fixture por `path`/`method` y devuelve la respuesta correspondiente.
- Actualizado `Package.swift` para incluir las `resources` de tests (`SwiftNetwork/Fakes/Fixtures`) y así exponer las fixtures a `FixtureLoader`.

### Testing
- No se ejecutaron pruebas automatizadas como parte de este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69690912f340832c978e6a9f3951723d)