### PR TITLE
Revertir cambios en inicializador de Response y mantener tests para nil response/error

### DIFF
--- a/Source/GIGLibraryTests/SwiftNetwork/ResponseTests.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/ResponseTests.swift
@@ -153,4 +153,27 @@ struct ResponseTests {
         #expect(response.data == nil)
     }
 
+    @Test("Given nil response and nil error, when Response initializes, then status is unknownError and statusCode is -1")
+    func responseInitializesWithNilResponseAndError() {
+        // When
+        let response = Response(data: nil, response: nil, error: nil)
+
+        // Then
+        #expect(response.status == .unknownError)
+        #expect(response.statusCode == -1)
+    }
+
+    @Test("Given nil response and nil error, when Response initializes, then it clears response-related properties")
+    func responseInitializesClearingResponseProperties() {
+        // When
+        let response = Response(data: nil, response: nil, error: nil)
+
+        // Then
+        #expect(response.body == nil)
+        #expect(response.data == nil)
+        #expect(response.error == nil)
+        #expect(response.url == nil)
+        #expect(response.headers == nil)
+    }
+
 }


### PR DESCRIPTION
### Motivation
- Ensure `Response` class behavior is not altered by test additions and keep the implementation unchanged for production code.
- Add coverage that validates `Response` initialization when both `response` and `error` are `nil` to avoid regressions.

### Description
- Reverted the `Response` convenience initializer to remove the additional forced clearing of response-related properties and restored the previous behavior in `Source/GIGLibrary/SwiftNetwork/Response.swift`.
- Kept setting of `self.error = error as NSError?` and restored existing logic that computes `statusCode` and `status` via `self.error?.code ?? -1` and `self.parseError(error:)` when `response` is `nil`.
- Added two tests in `Source/GIGLibraryTests/SwiftNetwork/ResponseTests.swift`: `responseInitializesWithNilResponseAndError` and `responseInitializesClearingResponseProperties` that assert the `Response` produced with `data: nil, response: nil, error: nil` yields `status == .unknownError`, `statusCode == -1`, and has `body`, `data`, `error`, `url`, and `headers` equal to `nil`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e5a7a2f8c832c9738acf088b34fdb)