### PR TITLE
Añadir NetworkLogManager inyectable y formateadores de logs

### DIFF
--- a/Source/GIGLibrary/SwiftNetwork/NetworkLogManaging.swift
+++ b/Source/GIGLibrary/SwiftNetwork/NetworkLogManaging.swift
@@ -1,0 +1,35 @@
+//
+//  NetworkLogManaging.swift
+//  GIGLibrary
+//
+//  Created by Alejandro Jiménez Agudo on 2026-01-20
+//  Copyright © 2026 Gigigo SL. All rights reserved.
+//
+
+import Foundation
+
+public protocol NetworkLogManaging {
+    func log(_ message: String, info: RequestLogInfo?)
+}
+
+public struct DefaultNetworkLogManager: NetworkLogManaging {
+    public init() {}
+
+    public func log(_ message: String, info: RequestLogInfo?) {
+        guard let info else {
+            print(message)
+            return
+        }
+
+        switch info.logLevel {
+        case .debug:
+            gigLogDebug(message, module: info.module, filename: info.filename, line: info.line, funcname: info.funcname, handler: info.handler)
+        case .error:
+            gigLogError(NSError(code: 0, message: message), module: info.module, filename: info.filename, line: info.line, funcname: info.funcname, handler: info.handler)
+        case .info:
+            gigLogInfo(message, module: info.module, filename: info.filename, line: info.line, funcname: info.funcname, handler: info.handler)
+        default:
+            break
+        }
+    }
+}

--- a/Source/GIGLibrary/SwiftNetwork/Request.swift
+++ b/Source/GIGLibrary/SwiftNetwork/Request.swift
@@ -52,6 +52,7 @@ open class Request: Selfie {
     open var bodyParamsArray: [[String: Any]]?
 	open var verbose = false
     open var logInfo: RequestLogInfo?
+    open var networkLogManager: NetworkLogManaging
     open var standardType: StandardType = .gigigo
     open var timeout: TimeInterval = 15.0
     open var cache: NSURLRequest.CachePolicy = NSURLRequest.CachePolicy.useProtocolCachePolicy
@@ -63,7 +64,7 @@ open class Request: Selfie {
     private let session: URLSession?
     
     // TODO , para versiones futuras borrar este metodo
-    public convenience init(method: String, baseUrl: String, endpoint: String, headers: [String: String]? = nil, urlParams: [String: Any]? = nil, bodyParams: [String: Any]? = nil, timeout: TimeInterval? = nil, verbose: Bool = false, sessionConfiguration: URLSessionConfiguration? = nil, session: URLSession? = nil, reachability: ReachabilityInput = ReachabilityWrapper.shared) {
+    public convenience init(method: String, baseUrl: String, endpoint: String, headers: [String: String]? = nil, urlParams: [String: Any]? = nil, bodyParams: [String: Any]? = nil, timeout: TimeInterval? = nil, verbose: Bool = false, sessionConfiguration: URLSessionConfiguration? = nil, session: URLSession? = nil, networkLogManager: NetworkLogManaging = DefaultNetworkLogManager(), reachability: ReachabilityInput = ReachabilityWrapper.shared) {
         self.init(
             method: method,
             baseUrl: baseUrl,
@@ -74,13 +75,14 @@ open class Request: Selfie {
             timeout: timeout,
             verbose: verbose,
             standard: .gigigo,
+            networkLogManager: networkLogManager,
             sessionConfiguration: sessionConfiguration,
             session: session,
             reachability: reachability
         )
     }
     
-    public convenience init(method: String, baseUrl: String, endpoint: String, headers: [String: String]? = nil, urlParams: [String: Any]? = nil, bodyParams: [String: Any]? = nil, timeout: TimeInterval? = nil, verbose: Bool = false, standard: StandardType = .gigigo, sessionConfiguration: URLSessionConfiguration? = nil, session: URLSession? = nil, reachability: ReachabilityInput = ReachabilityWrapper.shared) {
+    public convenience init(method: String, baseUrl: String, endpoint: String, headers: [String: String]? = nil, urlParams: [String: Any]? = nil, bodyParams: [String: Any]? = nil, timeout: TimeInterval? = nil, verbose: Bool = false, standard: StandardType = .gigigo, sessionConfiguration: URLSessionConfiguration? = nil, session: URLSession? = nil, networkLogManager: NetworkLogManaging = DefaultNetworkLogManager(), reachability: ReachabilityInput = ReachabilityWrapper.shared) {
         self.init(method: method,
             baseUrl: baseUrl,
             endpoint: endpoint,
@@ -91,12 +93,13 @@ open class Request: Selfie {
             verbose: verbose,
             standard: standard,
             logInfo: nil,
+            networkLogManager: networkLogManager,
             sessionConfiguration: sessionConfiguration,
             session: session,
             reachability: reachability)
     }
 
-    public init(method: String, baseUrl: String, endpoint: String, headers: [String: String]? = nil, urlParams: [String: Any]? = nil, bodyParams: [String: Any]? = nil, timeout: TimeInterval? = nil, verbose: Bool = false, standard: StandardType = .gigigo, logInfo: RequestLogInfo? = nil, sessionConfiguration: URLSessionConfiguration? = nil, session: URLSession? = nil, reachability: ReachabilityInput = ReachabilityWrapper.shared) {
+    public init(method: String, baseUrl: String, endpoint: String, headers: [String: String]? = nil, urlParams: [String: Any]? = nil, bodyParams: [String: Any]? = nil, timeout: TimeInterval? = nil, verbose: Bool = false, standard: StandardType = .gigigo, logInfo: RequestLogInfo? = nil, networkLogManager: NetworkLogManaging = DefaultNetworkLogManager(), sessionConfiguration: URLSessionConfiguration? = nil, session: URLSession? = nil, reachability: ReachabilityInput = ReachabilityWrapper.shared) {
         self.method = method
         self.baseURL = baseUrl
         self.endpoint = endpoint
@@ -107,12 +110,13 @@ open class Request: Selfie {
         self.verbose = verbose
         self.standardType = standard
         self.logInfo = logInfo
+        self.networkLogManager = networkLogManager
         self.sessionConfiguration = sessionConfiguration
         self.session = session
         self.reachability = reachability
     }
 
-    public convenience init(method: HTTPMethod, completeURL: URL, headers: [String: String]? = nil, urlParams: [String: Any]? = nil, bodyParams: [String: Any]? = nil, timeout: TimeInterval? = nil, verbose: Bool = false, standard: StandardType = .gigigo, sessionConfiguration: URLSessionConfiguration? = nil, session: URLSession? = nil, reachability: ReachabilityInput = ReachabilityWrapper.shared) {
+    public convenience init(method: HTTPMethod, completeURL: URL, headers: [String: String]? = nil, urlParams: [String: Any]? = nil, bodyParams: [String: Any]? = nil, timeout: TimeInterval? = nil, verbose: Bool = false, standard: StandardType = .gigigo, sessionConfiguration: URLSessionConfiguration? = nil, session: URLSession? = nil, networkLogManager: NetworkLogManaging = DefaultNetworkLogManager(), reachability: ReachabilityInput = ReachabilityWrapper.shared) {
         self.init(method: method,
             completeURL: completeURL, 
             headers: headers, 
@@ -122,12 +126,13 @@ open class Request: Selfie {
             verbose: verbose,
             standard: standard,
             logInfo: nil,
+            networkLogManager: networkLogManager,
             sessionConfiguration: sessionConfiguration,
             session: session,
             reachability: reachability)
     }
 
-    public init(method: HTTPMethod, completeURL: URL, headers: [String: String]? = nil, urlParams: [String: Any]? = nil, bodyParams: [String: Any]? = nil, timeout: TimeInterval? = nil, verbose: Bool = false, standard: StandardType = .gigigo, logInfo: RequestLogInfo? = nil, sessionConfiguration: URLSessionConfiguration? = nil, session: URLSession? = nil, reachability: ReachabilityInput = ReachabilityWrapper.shared) {
+    public init(method: HTTPMethod, completeURL: URL, headers: [String: String]? = nil, urlParams: [String: Any]? = nil, bodyParams: [String: Any]? = nil, timeout: TimeInterval? = nil, verbose: Bool = false, standard: StandardType = .gigigo, logInfo: RequestLogInfo? = nil, networkLogManager: NetworkLogManaging = DefaultNetworkLogManager(), sessionConfiguration: URLSessionConfiguration? = nil, session: URLSession? = nil, reachability: ReachabilityInput = ReachabilityWrapper.shared) {
         self.method = method.rawValue
         self.completeURL = completeURL
         self.baseURL = completeURL.absoluteString
@@ -139,6 +144,7 @@ open class Request: Selfie {
         self.verbose = verbose
         self.standardType = standard
         self.logInfo = logInfo
+        self.networkLogManager = networkLogManager
         self.sessionConfiguration = sessionConfiguration
         self.session = session
         self.reachability = reachability
@@ -163,7 +169,7 @@ open class Request: Selfie {
                 session.finishTasksAndInvalidate()
             }
             
-            let response = Response(data: data, response: urlResponse, error: error, standardType: self.standardType)
+            let response = Response(data: data, response: urlResponse, error: error, standardType: self.standardType, networkLogManager: self.networkLogManager)
 			
 			if self.verbose {
 				response.logResponse(self.logInfo)
@@ -197,7 +203,7 @@ open class Request: Selfie {
                 return
             }
             
-            let response = Response(data: nil, response: response, error: error, standardType: StandardType.basic)
+            let response = Response(data: nil, response: response, error: error, standardType: StandardType.basic, networkLogManager: self.networkLogManager)
             
             do {
                 if FileManager.default.fileExists(atPath: withDownloadUrlFile.path) {
@@ -253,7 +259,7 @@ open class Request: Selfie {
         
         self.task = session.uploadTask(with: request, from: bodyData, completionHandler: { data, urlResponse, error in
             
-            let response = Response(data: data, response: urlResponse, error: error, standardType: self.standardType)
+            let response = Response(data: data, response: urlResponse, error: error, standardType: self.standardType, networkLogManager: self.networkLogManager)
 
             if self.verbose {
                 response.logResponse(self.logInfo)
@@ -300,19 +306,6 @@ open class Request: Selfie {
         return URLSession(configuration: configuration, delegate: self as? URLSessionDelegate, delegateQueue: nil)
     }
 	
-    fileprivate func printLog(_ message: String, logInfo: RequestLogInfo) {
-        switch logInfo.logLevel {
-        case .debug:
-            gigLogDebug(message, module: logInfo.module, filename: logInfo.filename, line: logInfo.line, funcname: logInfo.funcname, handler: logInfo.handler)
-        case .error:
-            gigLogError(NSError(code: 0, message: message), module: logInfo.module, filename: logInfo.filename, line: logInfo.line, funcname: logInfo.funcname, handler: logInfo.handler)
-        case .info:
-            gigLogInfo(message, module: logInfo.module, filename: logInfo.filename, line: logInfo.line, funcname: logInfo.funcname, handler: logInfo.handler)
-        default:
-            break
-        }
-    }
-    
 	fileprivate func buildRequest() -> URLRequest? {
         var finalURL: URL?
         
@@ -326,11 +319,7 @@ open class Request: Selfie {
         guard let url = finalURL else { 
             if self.verbose {
                 let error = "not a valid URL"
-                if let logInfo = self.logInfo {
-                    printLog(error, logInfo: logInfo)
-                } else {
-                    print(error)
-                }
+                self.networkLogManager.log(error, info: self.logInfo)
             }
             return nil
         }
@@ -386,44 +375,8 @@ open class Request: Selfie {
             LogManager.shared.appName = "GIGLibrary"
         }
         
-		let url = self.request?.url?.absoluteString ?? "no url set"
-		let method = self.request?.httpMethod ?? "no method set"
-		
-		var log = "\n******** REQUEST ********\n"
-		log += " - URL:\t\t\(url)\n"
-		log += " - METHOD:\t\(method)\n"
-		let body = self.logBody()
-		let headers = self.logHeaders()
-		log += body + headers + "*************************\n\n"
-        
-        if let logInfo = self.logInfo {
-            printLog(log, logInfo: logInfo)
-        } else {
-            print(log)
-        }
-	}
-	
-	fileprivate func logBody() -> String {
-		guard
-			let body = self.request?.httpBody,
-			let json = try? JSON.dataToJson(body)
-			else { return "" }
-		
-		return " - BODY:\n\(json)\n"
-	}
-	
-	fileprivate func logHeaders() -> String {
-		guard let headers = self.request?.allHTTPHeaderFields, !headers.isEmpty else { return "" }
-		
-		var logString = " - HEADERS: {"
-		
-		for key in headers.keys {
-			if let value = headers[key] {
-				logString += "\n\t\t\(key): \(value)"
-			}
-		}
-		
-		return logString + "\n}\n"
+        let log = RequestLogFormatter.buildRequestLog(request: self.request)
+        self.networkLogManager.log(log, info: self.logInfo)
 	}
     
     fileprivate func generateBoundary() -> String? {

--- a/Source/GIGLibrary/SwiftNetwork/RequestLogFormatter.swift
+++ b/Source/GIGLibrary/SwiftNetwork/RequestLogFormatter.swift
@@ -1,0 +1,48 @@
+//
+//  RequestLogFormatter.swift
+//  GIGLibrary
+//
+//  Created by Alejandro Jiménez Agudo on 2026-01-20
+//  Copyright © 2026 Gigigo SL. All rights reserved.
+//
+
+import Foundation
+
+public enum RequestLogFormatter {
+    public static func buildRequestLog(request: URLRequest?) -> String {
+        let url = request?.url?.absoluteString ?? "no url set"
+        let method = request?.httpMethod ?? "no method set"
+
+        var log = "\n******** REQUEST ********\n"
+        log += " - URL:\t\t\(url)\n"
+        log += " - METHOD:\t\(method)\n"
+        log += logBody(request: request)
+        log += logHeaders(request: request)
+        log += "*************************\n\n"
+
+        return log
+    }
+
+    private static func logBody(request: URLRequest?) -> String {
+        guard
+            let body = request?.httpBody,
+            let json = try? JSON.dataToJson(body)
+        else { return "" }
+
+        return " - BODY:\n\(json)\n"
+    }
+
+    private static func logHeaders(request: URLRequest?) -> String {
+        guard let headers = request?.allHTTPHeaderFields, !headers.isEmpty else { return "" }
+
+        var logString = " - HEADERS: {"
+
+        for key in headers.keys {
+            if let value = headers[key] {
+                logString += "\n\t\t\(key): \(value)"
+            }
+        }
+
+        return logString + "\n}\n"
+    }
+}

--- a/Source/GIGLibrary/SwiftNetwork/Response.swift
+++ b/Source/GIGLibrary/SwiftNetwork/Response.swift
@@ -34,6 +34,7 @@ open class Response: Selfie {
 	open var body: Data?
 	open var data: JSON?
 	open var error: NSError?
+    open var networkLogManager: NetworkLogManaging
     var standardType: StandardType = .gigigo
 	
 	
@@ -42,11 +43,13 @@ open class Response: Selfie {
 	init() {
 		self.status = .unknownError
 		self.statusCode = 0
+        self.networkLogManager = DefaultNetworkLogManager()
 	}
 	
-    convenience init(data: Data?, response: URLResponse?, error: Error?, standardType: StandardType = .gigigo) {
+    convenience init(data: Data?, response: URLResponse?, error: Error?, standardType: StandardType = .gigigo, networkLogManager: NetworkLogManaging = DefaultNetworkLogManager()) {
 		self.init()
 		
+        self.networkLogManager = networkLogManager
         self.standardType = standardType
 		self.error = error as NSError?
 		if let response = response as? HTTPURLResponse {
@@ -150,67 +153,8 @@ open class Response: Selfie {
     }
 	
     func logResponse(_ logInfo: RequestLogInfo?) {
-		var log = "\n******** RESPONSE ********\n"
-		log += " - URL:\t" + self.logURL() + "\n"
-		log += " - CODE:\t" + "\(self.statusCode)\n"
-		let headers = self.logHeaders()
-		let data = self.logData()
-		log += headers + data + "*************************\n\n"
-        
-        if let logInfo = logInfo {
-            printLog(log, logInfo: logInfo)
-        } else {
-            print(log)
-        }
-	}
-    
-    fileprivate func printLog(_ message: String, logInfo: RequestLogInfo) {
-        switch logInfo.logLevel {
-        case .debug:
-            gigLogDebug(message, module: logInfo.module, filename: logInfo.filename, line: logInfo.line, funcname: logInfo.funcname, handler: logInfo.handler)
-        case .error:
-            gigLogError(NSError(code: 0, message: message), module: logInfo.module, filename: logInfo.filename, line: logInfo.line, funcname: logInfo.funcname, handler: logInfo.handler)
-        case .info:
-            gigLogInfo(message, module: logInfo.module, filename: logInfo.filename, line: logInfo.line, funcname: logInfo.funcname, handler: logInfo.handler)
-        default:
-            break
-        }
-    }
-	
-	private func logURL() -> String {
-		guard let url = self.url?.absoluteString else {
-			return "NO URL"
-		}
-		
-		return url
-	}
-	
-	private func logHeaders() -> String {
-		guard let headers = self.headers else { return "" }
-		
-		var log = " - HEADERS: {"
-		
-		for key in headers.keys {
-			if let value = headers[key] {
-				log += "\n\t\t\(key): \(value)"
-			}
-		}
-		
-		return log + "\n}\n"
-	}
-	
-	private func logData() -> String {
-		guard let body = self.body else {
-			return ""
-		}
-		
-		if let json = try? JSON.dataToJson(body) {
-			return " - JSON:\n\(json)\n"
-		} else if let string = String(data: body, encoding: .utf8) {
-			return" - DATA:\n\(string)\n"
-        } else {
-            return ""
-        }
+        let log = ResponseLogFormatter.buildResponseLog(url: self.url, statusCode: self.statusCode, headers: self.headers, body: self.body)
+        self.networkLogManager.log(log, info: logInfo)
 	}
 }
 

--- a/Source/GIGLibrary/SwiftNetwork/ResponseLogFormatter.swift
+++ b/Source/GIGLibrary/SwiftNetwork/ResponseLogFormatter.swift
@@ -1,0 +1,58 @@
+//
+//  ResponseLogFormatter.swift
+//  GIGLibrary
+//
+//  Created by Alejandro Jiménez Agudo on 2026-01-20
+//  Copyright © 2026 Gigigo SL. All rights reserved.
+//
+
+import Foundation
+
+public enum ResponseLogFormatter {
+    public static func buildResponseLog(url: URL?, statusCode: Int, headers: [AnyHashable: Any]?, body: Data?) -> String {
+        var log = "\n******** RESPONSE ********\n"
+        log += " - URL:\t" + logURL(url) + "\n"
+        log += " - CODE:\t" + "\(statusCode)\n"
+        log += logHeaders(headers)
+        log += logData(body)
+        log += "*************************\n\n"
+
+        return log
+    }
+
+    private static func logURL(_ url: URL?) -> String {
+        guard let url = url?.absoluteString else {
+            return "NO URL"
+        }
+
+        return url
+    }
+
+    private static func logHeaders(_ headers: [AnyHashable: Any]?) -> String {
+        guard let headers = headers, !headers.isEmpty else { return "" }
+
+        var log = " - HEADERS: {"
+
+        for key in headers.keys {
+            if let value = headers[key] {
+                log += "\n\t\t\(key): \(value)"
+            }
+        }
+
+        return log + "\n}\n"
+    }
+
+    private static func logData(_ body: Data?) -> String {
+        guard let body = body else {
+            return ""
+        }
+
+        if let json = try? JSON.dataToJson(body) {
+            return " - JSON:\n\(json)\n"
+        } else if let string = String(data: body, encoding: .utf8) {
+            return " - DATA:\n\(string)\n"
+        } else {
+            return ""
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Permitir la inyección y personalización del mecanismo de logging en la capa de red para facilitar pruebas y suplantación en distintos entornos. 
- Centralizar la construcción de los strings de log para poder verificar su contenido en tests sin depender del side-effect de impresión. 

### Description
- Se añade el protocolo `NetworkLogManaging` y la implementación por defecto `DefaultNetworkLogManager` con el método `log(_ message: String, info: RequestLogInfo?)` que delega en `gigLog*` o en `print` si `info` es `nil`.
- Se introducen los formateadores `RequestLogFormatter` y `ResponseLogFormatter` con `buildRequestLog` y `buildResponseLog` para construir los textos de log de petición y respuesta respectivamente.
- Se modifica `Request` para incluir la propiedad `networkLogManager`, se actualizan los inicializadores para aceptar `networkLogManager: NetworkLogManaging = DefaultNetworkLogManager()` y se propaga el manager a las instancias `Response` que se crean; además se reemplazan las llamadas a los viejos `print`/`gigLog*` por `networkLogManager.log(...)` usando los formateadores.
- Se actualizan `Response` para almacenar y usar `networkLogManager` en su logging y se eliminan los métodos de impresión de logs internos

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f41a3ec6c832cae43c64a4d418a0f)