### PR TITLE
Añadir NetworkLogManagerSpy e tests para logs de Request/Response

### DIFF
--- a/Source/GIGLibraryTests/SwiftNetwork/Mocks/NetworkLogManagerSpy.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/Mocks/NetworkLogManagerSpy.swift
@@ -1,0 +1,20 @@
+import Foundation
+@testable import GIGLibrary
+
+final class NetworkLogManagerSpy: NetworkLogManaging {
+    private(set) var messages: [String] = []
+    private(set) var infos: [RequestLogInfo?] = []
+
+    var lastMessage: String? {
+        return messages.last
+    }
+
+    var invocationCount: Int {
+        return messages.count
+    }
+
+    func log(_ message: String, info: RequestLogInfo?) {
+        messages.append(message)
+        infos.append(info)
+    }
+}

--- a/Source/GIGLibraryTests/SwiftNetwork/Mocks/RequestMocks.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/Mocks/RequestMocks.swift
@@ -281,7 +281,8 @@ extension Request {
         verbose: Bool = false,
         standard: StandardType = .gigigo,
         sessionConfiguration: URLSessionConfiguration? = nil,
-        reachable: Bool = true
+        reachable: Bool = true,
+        networkLogManager: NetworkLogManaging = DefaultNetworkLogManager()
     ) -> Request {
         let configuration = sessionConfiguration ?? .testConfiguration()
         return Request(
@@ -294,6 +295,7 @@ extension Request {
             timeout: timeout,
             verbose: verbose,
             standard: standard,
+            networkLogManager: networkLogManager,
             sessionConfiguration: configuration,
             reachability: MockReachabilityProvider(reachable: reachable)
         )

--- a/Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift
@@ -451,4 +451,157 @@ struct RequestTests {
             #expect(configuration.urlCache == nil)
         }
     }
+
+    @Test("Given verbose request, when fetch is called, then request log includes URL, METHOD, and separator")
+    func requestLogIncludesUrlMethodAndSeparator() async throws {
+        // Given
+        let spy = NetworkLogManagerSpy()
+
+        MockURLProtocol.respond(path: "/log") { _ in }
+
+        let request = Request.testRequest(
+            method: HTTPMethod.post.rawValue,
+            baseUrl: "https://example.com",
+            endpoint: "/log",
+            headers: nil,
+            urlParams: nil,
+            bodyParams: nil,
+            verbose: true,
+            networkLogManager: spy
+        )
+
+        // When
+        _ = await withCheckedContinuation { continuation in
+            request.fetch { _ in
+                continuation.resume(returning: ())
+            }
+        }
+
+        // Then
+        let message = try #require(spy.messages.first)
+
+        #expect(message.contains("******** REQUEST ********"))
+        #expect(message.contains(" - URL:\t\thttps://example.com/log"))
+        #expect(message.contains(" - METHOD:\tPOST"))
+    }
+
+    @Test("Given verbose request with body params, when fetch is called, then request log includes JSON body")
+    func requestLogIncludesBodyParamsJson() async throws {
+        // Given
+        let spy = NetworkLogManagerSpy()
+
+        MockURLProtocol.respond(path: "/body") { _ in }
+
+        let request = Request.testRequest(
+            method: HTTPMethod.post.rawValue,
+            baseUrl: "https://example.com",
+            endpoint: "/body",
+            headers: nil,
+            urlParams: nil,
+            bodyParams: ["name": "Taylor", "count": 3],
+            verbose: true,
+            networkLogManager: spy
+        )
+
+        // When
+        _ = await withCheckedContinuation { continuation in
+            request.fetch { _ in
+                continuation.resume(returning: ())
+            }
+        }
+
+        // Then
+        let message = try #require(spy.messages.first)
+
+        #expect(message.contains(" - BODY:\n"))
+        #expect(message.contains("\"name\" : \"Taylor\""))
+        #expect(message.contains("\"count\" : 3"))
+    }
+
+    @Test("Given verbose requests with and without headers, when fetch is called, then log includes headers only when present")
+    func requestLogIncludesHeadersOnlyWhenPresent() async throws {
+        // Given
+        let spyWithHeaders = NetworkLogManagerSpy()
+        let spyWithoutHeaders = NetworkLogManagerSpy()
+
+        MockURLProtocol.respond(path: "/headers") { _ in }
+        MockURLProtocol.respond(path: "/no-headers") { _ in }
+
+        let requestWithHeaders = Request.testRequest(
+            method: HTTPMethod.get.rawValue,
+            baseUrl: "https://example.com",
+            endpoint: "/headers",
+            headers: ["Authorization": "Bearer 123"],
+            urlParams: nil,
+            bodyParams: nil,
+            verbose: true,
+            networkLogManager: spyWithHeaders
+        )
+
+        let requestWithoutHeaders = Request.testRequest(
+            method: HTTPMethod.get.rawValue,
+            baseUrl: "https://example.com",
+            endpoint: "/no-headers",
+            headers: nil,
+            urlParams: nil,
+            bodyParams: nil,
+            verbose: true,
+            networkLogManager: spyWithoutHeaders
+        )
+
+        // When
+        _ = await withCheckedContinuation { continuation in
+            requestWithHeaders.fetch { _ in
+                continuation.resume(returning: ())
+            }
+        }
+
+        _ = await withCheckedContinuation { continuation in
+            requestWithoutHeaders.fetch { _ in
+                continuation.resume(returning: ())
+            }
+        }
+
+        // Then
+        let messageWithHeaders = try #require(spyWithHeaders.messages.first)
+        let messageWithoutHeaders = try #require(spyWithoutHeaders.messages.first)
+
+        #expect(messageWithHeaders.contains(" - HEADERS:"))
+        #expect(messageWithHeaders.contains("Authorization: Bearer 123"))
+        #expect(messageWithoutHeaders.contains(" - HEADERS:") == false)
+    }
+
+    @Test("Given verbose request with body params array, when fetch is called, then request log includes JSON array body")
+    func requestLogIncludesBodyParamsArray() async throws {
+        // Given
+        let spy = NetworkLogManagerSpy()
+
+        MockURLProtocol.respond(path: "/array") { _ in }
+
+        let request = Request.testRequest(
+            method: HTTPMethod.post.rawValue,
+            baseUrl: "https://example.com",
+            endpoint: "/array",
+            headers: nil,
+            urlParams: nil,
+            bodyParams: nil,
+            verbose: true,
+            networkLogManager: spy
+        )
+        request.bodyParamsArray = [["id": 1], ["id": 2]]
+
+        // When
+        _ = await withCheckedContinuation { continuation in
+            request.fetch { _ in
+                continuation.resume(returning: ())
+            }
+        }
+
+        // Then
+        let message = try #require(spy.messages.first)
+
+        #expect(message.contains(" - BODY:\n["))
+        #expect(message.contains("\"id\" : 1"))
+        #expect(message.contains("\"id\" : 2"))
+    }
 }

--- a/Source/GIGLibraryTests/SwiftNetwork/ResponseTests.swift
+++ b/Source/GIGLibraryTests/SwiftNetwork/ResponseTests.swift
@@ -235,4 +235,76 @@ struct ResponseTests {
         }
     }
 
+    @Test("Given a response, when logging, then it includes URL and status code")
+    func responseLogIncludesUrlAndCode() throws {
+        // Given
+        let spy = NetworkLogManagerSpy()
+        let url = try #require(URL(string: "https://example.com/resource"))
+        let httpResponse = HTTPURLResponse.fake(url: url, statusCode: 201, headers: nil)
+        let response = Response(data: nil, response: httpResponse, error: nil, networkLogManager: spy)
+
+        // When
+        response.logResponse()
+
+        // Then
+        let message = try #require(spy.lastMessage)
+        #expect(message.contains("******** RESPONSE ********"))
+        #expect(message.contains(" - URL:\thttps://example.com/resource"))
+        #expect(message.contains(" - CODE:\t201"))
+    }
+
+    @Test("Given a JSON response body, when logging, then it includes the JSON section")
+    func responseLogIncludesJsonBody() throws {
+        // Given
+        let spy = NetworkLogManagerSpy()
+        let url = try #require(URL(string: "https://example.com/json"))
+        let body: [String: Any] = ["name": "Taylor", "count": 2]
+        let data = try JSONSerialization.data(withJSONObject: body, options: [])
+        let httpResponse = HTTPURLResponse.fake(url: url, statusCode: 200, headers: ["Content-Type": "application/json"])
+        let response = Response(data: data, response: httpResponse, error: nil, networkLogManager: spy)
+
+        // When
+        response.logResponse()
+
+        // Then
+        let message = try #require(spy.lastMessage)
+        #expect(message.contains(" - JSON:\n"))
+        #expect(message.contains("\"name\" : \"Taylor\""))
+        #expect(message.contains("\"count\" : 2"))
+    }
+
+    @Test("Given a non-JSON string body, when logging, then it includes the data section")
+    func responseLogIncludesStringBodyAsData() throws {
+        // Given
+        let spy = NetworkLogManagerSpy()
+        let url = try #require(URL(string: "https://example.com/text"))
+        let data = try #require("plain text".data(using: .utf8))
+        let httpResponse = HTTPURLResponse.fake(url: url, statusCode: 200, headers: nil)
+        let response = Response(data: data, response: httpResponse, error: nil, networkLogManager: spy)
+
+        // When
+        response.logResponse()
+
+        // Then
+        let message = try #require(spy.lastMessage)
+        #expect(message.contains(" - DATA:\nplain text"))
+    }
+
+    @Test("Given a response without headers or body, when logging, then it omits those sections")
+    func responseLogOmitsHeadersAndBodyWhenEmpty() throws {
+        // Given
+        let spy = NetworkLogManagerSpy()
+        let url = try #require(URL(string: "https://example.com/empty"))
+        let httpResponse = HTTPURLResponse.fake(url: url, statusCode: 204, headers: nil)
+        let response = Response(data: nil, response: httpResponse, error: nil, networkLogManager: spy)
+
+        // When
+        response.logResponse()
+
+        // Then
+        let message = try #require(spy.lastMessage)
+        #expect(message.contains(" - HEADERS:") == false)
+        #expect(message.contains(" - JSON:") == false)
+        #expect(message.contains(" - DATA:") == false)
+    }
 }


### PR DESCRIPTION
### Motivation

- Permitir verificar de forma determinista el contenido de los logs generados por `Request` y `Response` cuando `verbose` está activado. 

### Description

- Se añade `NetworkLogManagerSpy` en `Source/GIGLibraryTests/SwiftNetwork/Mocks` que captura `messages`, `infos`, `lastMessage` e `invocationCount` para inspección en tests. 
- Se modifica el helper de tests `Request.testRequest` para aceptar un `networkLogManager: NetworkLogManaging` inyectable y así poder pasar el spy. 
- Se añaden tests en `Source/GIGLibraryTests/SwiftNetwork/RequestTests.swift` que comprueban que el log de request contiene el separador `******** REQUEST ********`, la `URL`, la `METHOD`, la sección ` - BODY:` con JSON (incluyendo `bodyParamsArray`) y que la sección ` - HEADERS:` solo aparece cuando hay headers. 
- Se añaden tests en `Source/GIGLibraryTests/SwiftNetwork/ResponseTests.swift` que comprueban que el log de response contiene la `URL` y `CODE`, que imprime ` - JSON:` cuando el body es JSON, que imprime ` - DATA:` cuando el body es texto plano, y que omite las secciones de headers/body cuando no aplican. 

### Testing

- Se añadieron pruebas unitarias en `RequestTests` y `ResponseTests`, pero no se ejecutaron pruebas automatizadas durante este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f63d1a250832c8e2db346f3a7eab3)