### PR TITLE
Corregir cabecera y consolidar helper de ventana activa

### DIFF
--- a/Sources/GIGLibrary/GIGUtils/Application/Application.swift
+++ b/Sources/GIGLibrary/GIGUtils/Application/Application.swift
@@ -52,7 +52,7 @@ open class Application {
 	
 	private func topViewController() -> UIViewController? {
 		let app = UIApplication.shared
-		let window = app.keyWindow
+		let window = app.activeWindow
 		var rootVC = window?.rootViewController
 		while let presentedController = rootVC?.presentedViewController {
 			rootVC = presentedController

--- a/Sources/GIGLibrary/GIGUtils/Application/UIApplication+Window.swift
+++ b/Sources/GIGLibrary/GIGUtils/Application/UIApplication+Window.swift
@@ -1,0 +1,22 @@
+//
+//  UIApplication+Window.swift
+//  GIGLibrary
+//
+//  Created by Alejandro Jiménez Agudo on 2025-09-14
+//  Copyright © 2025 Gigigo. All rights reserved.
+//
+
+import UIKit
+
+extension UIApplication {
+    var activeWindow: UIWindow? {
+        if #available(iOS 13.0, *) {
+            let windows = connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap { $0.windows }
+            return windows.first { $0.isKeyWindow } ?? windows.first
+        }
+
+        return keyWindow
+    }
+}

--- a/Sources/GIGLibrary/GIGUtils/Application/UIApplication+Window.swift
+++ b/Sources/GIGLibrary/GIGUtils/Application/UIApplication+Window.swift
@@ -11,6 +11,14 @@ import UIKit
 extension UIApplication {
     var activeWindow: UIWindow? {
         if #available(iOS 13.0, *) {
+            let activeScenes = connectedScenes
+                .filter { $0.activationState == .foregroundActive }
+                .compactMap { $0 as? UIWindowScene }
+            let activeWindows = activeScenes.flatMap { $0.windows }
+            if let window = activeWindows.first(where: { $0.isKeyWindow }) ?? activeWindows.first {
+                return window
+            }
+
             let windows = connectedScenes
                 .compactMap { $0 as? UIWindowScene }
                 .flatMap { $0.windows }

--- a/Sources/GIGLibrary/GIGUtils/Keyboard/KeyboardAdaptable.swift
+++ b/Sources/GIGLibrary/GIGUtils/Keyboard/KeyboardAdaptable.swift
@@ -63,13 +63,13 @@ public extension KeyboardAdaptable where Self: UIViewController {
             }
 			self.animateKeyboardChanges(notification,
 				changes: {
-					if var appHeight = UIApplication.shared.keyWindow?.frame.height {
+					if let window = UIApplication.shared.activeWindow, var appHeight = window.frame.height {
                         if self.navigationController != nil {
                             appHeight -= self.navigationController?.navigationBar.frame.size.height ?? 0
                         }
                         if #available(iOS 11.0, *) {
-                            let safeAreaInsetsBottomHeight = (UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0)
-                            let safeAreaInsetsTopHeight = (UIApplication.shared.keyWindow?.safeAreaInsets.top ?? 0)
+							let safeAreaInsetsBottomHeight = window.safeAreaInsets.bottom
+							let safeAreaInsetsTopHeight = window.safeAreaInsets.top
                             let statusBarHeight = UIApplication.shared.statusBarFrame.size.height
 							self.view.frame.size.height = appHeight - safeAreaInsetsBottomHeight + safeAreaInsetsTopHeight - statusBarHeight - size.height
                         } else {
@@ -89,7 +89,7 @@ public extension KeyboardAdaptable where Self: UIViewController {
 			self.keyboardWillHide()
 			self.animateKeyboardChanges(notification,
 				changes: {
-					if var appHeight = UIApplication.shared.keyWindow?.frame.height {
+					if let window = UIApplication.shared.activeWindow, var appHeight = window.frame.height {
                         if self.navigationController != nil {
                             appHeight -= self.navigationController?.navigationBar.frame.size.height ?? 0
                         }

--- a/Sources/GIGLibrary/GIGUtils/Keyboard/KeyboardAdaptable.swift
+++ b/Sources/GIGLibrary/GIGUtils/Keyboard/KeyboardAdaptable.swift
@@ -63,7 +63,8 @@ public extension KeyboardAdaptable where Self: UIViewController {
             }
 			self.animateKeyboardChanges(notification,
 				changes: {
-					if let window = UIApplication.shared.activeWindow, var appHeight = window.frame.height {
+					if let window = UIApplication.shared.activeWindow {
+                        var appHeight = window.frame.height
                         if self.navigationController != nil {
                             appHeight -= self.navigationController?.navigationBar.frame.size.height ?? 0
                         }
@@ -89,7 +90,8 @@ public extension KeyboardAdaptable where Self: UIViewController {
 			self.keyboardWillHide()
 			self.animateKeyboardChanges(notification,
 				changes: {
-					if let window = UIApplication.shared.activeWindow, var appHeight = window.frame.height {
+					if let window = UIApplication.shared.activeWindow {
+                        var appHeight = window.frame.height
                         if self.navigationController != nil {
                             appHeight -= self.navigationController?.navigationBar.frame.size.height ?? 0
                         }

--- a/Sources/GIGLibrary/GIGUtils/View/View+Extension.swift
+++ b/Sources/GIGLibrary/GIGUtils/View/View+Extension.swift
@@ -80,7 +80,7 @@ extension UIView {
     
     public func show(alertContainerView: UIView, blurEffectView: UIVisualEffectView) {
         self.isHidden = true
-        guard let window = UIApplication.shared.keyWindow else { return }
+        guard let window = UIApplication.shared.activeWindow else { return }
         window.endEditing(true)
         window.addSubview(self)
         self.layout(using: [


### PR DESCRIPTION
### Motivation
- Replace unsafe `keyWindow` access with a safe `activeWindow` lookup that works across iOS versions and keeps compatibility with the iOS 12 deployment target.
- Ensure the new helper file header follows the required author and copyright format.

### Description
- Added a `UIApplication` extension `activeWindow` in `Sources/GIGLibrary/GIGUtils/Application/UIApplication+Window.swift` that uses `connectedScenes`/`UIWindowScene.windows` on iOS 13+ and falls back to `keyWindow` otherwise.
- Replaced direct uses of `UIApplication.shared.keyWindow` with `UIApplication.shared.activeWindow` in `Sources/GIGLibrary/GIGUtils/Application/Application.swift`, `Sources/GIGLibrary/GIGUtils/Keyboard/KeyboardAdaptable.swift` and `Sources/GIGLibrary/GIGUtils/View/View+Extension.swift`.
- Updated `KeyboardAdaptable` to read `safeAreaInsets` from the resolved `window` instead of from `keyWindow` to correctly compute view heights.

### Testing
- No automated tests were executed for these changes.
- Code changes were committed successfully with no automated test failures reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978f20b43a8832c86dbe9784f95eb74)