### PR TITLE
Comprobar `Accept` y `Content-Type` insensible a mayúsculas

### DIFF
--- a/Sources/GIGLibrary/SwiftNetwork/Request.swift
+++ b/Sources/GIGLibrary/SwiftNetwork/Request.swift
@@ -334,6 +334,9 @@ public class Request: Selfie {
 		var request = URLRequest(url: url, cachePolicy: .useProtocolCachePolicy, timeoutInterval: self.timeout)
 		request.httpMethod = self.method.rawValue
 		request.allHTTPHeaderFields = self.headers
+        if request.allHTTPHeaderFields?.keys.contains(where: { $0.caseInsensitiveCompare("Accept") == .orderedSame }) != true {
+            request.addValue("application/json", forHTTPHeaderField: "Accept")
+        }
 		
 		// Set body is not GET
 		if self.method != .get {
@@ -344,8 +347,7 @@ public class Request: Selfie {
             }
 			
 			// Add Content-Type if it wasn't set
-			if let containsContentType = request.allHTTPHeaderFields?.keys.contains("Content-Type"),
-				!containsContentType {
+			if request.allHTTPHeaderFields?.keys.contains(where: { $0.caseInsensitiveCompare("Content-Type") == .orderedSame }) != true {
 				request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 			}
 		}


### PR DESCRIPTION
### Motivation
- Evitar añadir por defecto encabezados `Accept` o `Content-Type` cuando el consumidor ya proporcionó esos encabezados con distinto casing, respetando la naturaleza case-insensitive de los nombres de header.

### Description
- Update `Sources/GIGLibrary/SwiftNetwork/Request.swift` to add a case-insensitive presence check for the `Accept` header before adding the default `application/json` value using `keys.contains(where: { $0.caseInsensitiveCompare("Accept") == .orderedSame })`.
- Replace the previous `Content-Type` presence check with a case-insensitive lookup using `keys.contains(where: { $0.caseInsensitiveCompare("Content-Type") == .orderedSame })` and add `application/json` only when absent.
- The change ensures that headers provided with alternative casing (for example `content-type` or `ACCEPT`) are respected and no duplicate defaults are added.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978f1129cd4832c85dadc1f44f69c8f)