### PR TITLE
Actualizar Package.swift a iOS 16 y swift-tools-version 5.7

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
 	name: "GIGLibrary",
 	platforms: [
-		.iOS(.v12)
+		.iOS(.v16)
 	],
 	products: [
 		// Products define the executables and libraries produced by a package, and make them visible to other packages.


### PR DESCRIPTION
### Motivation
- Subir el platform target a iOS 16 y actualizar la herramienta Swift requerida para asegurar compatibilidad con versiones modernas de Xcode/Swift.

### Description
- Se actualizó `// swift-tools-version:5.5` a `// swift-tools-version:5.7` y se cambió `platforms: [.iOS(.v12)]` a `platforms: [.iOS(.v16)]` en `Package.swift`, y no se encontraron dependencias declaradas que requieran versiones de plataforma inferiores.

### Testing
- No se ejecutaron pruebas automatizadas; el cambio se limitó al manifiesto `Package.swift` y se verificó visualmente su contenido.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978ff8d0694832c98baf6e3a335314d)