### PR TITLE
Eliminar checks de disponibilidad iOS obsoletos

### DIFF
--- a/Sources/GIGLibrary/GIGUtils/Application/Application.swift
+++ b/Sources/GIGLibrary/GIGUtils/Application/Application.swift
@@ -33,11 +33,7 @@ open class Application {
 			return LogWarn("Can not open url: \(urlString)")
 		}
 		
-		if #available(iOS 10.0, *) {
-			UIApplication.shared.open(url)
-		} else {
-			UIApplication.shared.openURL(url)
-		}
+		UIApplication.shared.open(url)
 	}
 	
 	public func presentModal(_ viewController: UIViewController) {

--- a/Sources/GIGLibrary/GIGUtils/Keyboard/KeyboardAdaptable.swift
+++ b/Sources/GIGLibrary/GIGUtils/Keyboard/KeyboardAdaptable.swift
@@ -68,14 +68,10 @@ public extension KeyboardAdaptable where Self: UIViewController {
                         if self.navigationController != nil {
                             appHeight -= self.navigationController?.navigationBar.frame.size.height ?? 0
                         }
-                        if #available(iOS 11.0, *) {
-							let safeAreaInsetsBottomHeight = window.safeAreaInsets.bottom
-							let safeAreaInsetsTopHeight = window.safeAreaInsets.top
-                            let statusBarHeight = UIApplication.shared.statusBarFrame.size.height
-							self.view.frame.size.height = appHeight - safeAreaInsetsBottomHeight + safeAreaInsetsTopHeight - statusBarHeight - size.height
-                        } else {
-							self.view.frame.size.height = appHeight - size.height
-                        }
+                        let safeAreaInsetsBottomHeight = window.safeAreaInsets.bottom
+                        let safeAreaInsetsTopHeight = window.safeAreaInsets.top
+                        let statusBarHeight = UIApplication.shared.statusBarFrame.size.height
+                        self.view.frame.size.height = appHeight - safeAreaInsetsBottomHeight + safeAreaInsetsTopHeight - statusBarHeight - size.height
                     }
 				},
 				onCompletion: {

--- a/Sources/GIGLibrary/GIGUtils/QRGenerator/QRGenerator.swift
+++ b/Sources/GIGLibrary/GIGUtils/QRGenerator/QRGenerator.swift
@@ -44,25 +44,13 @@ open class QR {
 	
 	fileprivate class func generate(_ string: String) -> CGImage? {
         let context = CIContext()
-        if #available(iOS 13.0, *) {
-            let filter = CIFilter.qrCodeGenerator()
-            filter.message = Data(string.utf8)
-            let transform = CGAffineTransform(scaleX: 10, y: 10)
-            guard let outputImage = filter.outputImage?.transformed(by: transform),
-                  let cgimg = context.createCGImage(outputImage, from: outputImage.extent) else {
-                    return nil
-            }
-            return cgimg
-        } else {
-            let stringData = string.data(using: String.Encoding.utf8)
-            let filter = CIFilter(name: "CIQRCodeGenerator")
-            filter?.setValue(stringData, forKey: "inputMessage")
-            filter?.setValue("H", forKey: "inputCorrectionLevel")
-            guard let outputImage = filter?.outputImage,
-                  let cgimg = context.createCGImage(outputImage, from: outputImage.extent) else {
-                    return nil
-            }
-            return cgimg
+        let filter = CIFilter.qrCodeGenerator()
+        filter.message = Data(string.utf8)
+        let transform = CGAffineTransform(scaleX: 10, y: 10)
+        guard let outputImage = filter.outputImage?.transformed(by: transform),
+              let cgimg = context.createCGImage(outputImage, from: outputImage.extent) else {
+                return nil
         }
+        return cgimg
 	}
 }

--- a/Sources/GIGLibrary/GIGUtils/Style/StylableExtensions/UIView+ViewStylable.swift
+++ b/Sources/GIGLibrary/GIGUtils/Style/StylableExtensions/UIView+ViewStylable.swift
@@ -22,11 +22,7 @@ extension UIView: ViewStylable {
         // Some borders - not dotted border
         else if style.someBorders.count > 0 {
             style.someBorders.forEach {
-                if #available(iOS 9.0, *) {
-                    self.addSomeBorders($0, weight: style.borderWidth, color: style.borderColor)
-                } else {
-                    // Fallback on earlier versions
-                }
+                self.addSomeBorders($0, weight: style.borderWidth, color: style.borderColor)
             }
         }
         

--- a/Sources/GIGLibrary/GIGUtils/Style/UIKitExtensions/UIView+Borders.swift
+++ b/Sources/GIGLibrary/GIGUtils/Style/UIKitExtensions/UIView+Borders.swift
@@ -11,7 +11,6 @@ private final class BorderView: UIView { }
 
 public extension UIView {
     
-    @available(iOS 9.0, *)
     func addSomeBorders(_ border: Border, weight: CGFloat, color: UIColor) {
 		
 		resetBorder(border)

--- a/Sources/GIGLibrary/GIGUtils/View/View+Extension.swift
+++ b/Sources/GIGLibrary/GIGUtils/View/View+Extension.swift
@@ -46,9 +46,7 @@ extension UIView {
     
     public func setCornerRadius(to radius: CGFloat = 8) {
         self.layer.cornerRadius = radius
-        if #available(iOS 13.0, *) {
-            self.layer.cornerCurve = .continuous
-        }
+        self.layer.cornerCurve = .continuous
     }
     
     public func layout(using constraints: [NSLayoutConstraint]) {

--- a/Sources/GIGLibrary/SwiftNetwork/Request.swift
+++ b/Sources/GIGLibrary/SwiftNetwork/Request.swift
@@ -305,9 +305,7 @@ public class Request: Selfie {
 
         let configuration = self.sessionConfiguration ?? URLSessionConfiguration.default
         configuration.timeoutIntervalForResource = self.timeout
-        if #available(iOS 11, *) {
-            configuration.waitsForConnectivity = true
-        }
+        configuration.waitsForConnectivity = true
         if applyCache {
             self.controlCache(config: configuration)
         }


### PR DESCRIPTION
### Motivation
- Modernize code by removing legacy `#available` guards and fallbacks that target old iOS versions and simplify runtime behavior. 
- Ensure network sessions always use `waitsForConnectivity` to rely on system connectivity behavior.

### Description
- Replace conditional URL opening in `Application.openUrl` to always call `UIApplication.shared.open(url)` (removed the iOS 10 fallback). 
- Always set `configuration.waitsForConnectivity = true` in `Request.configuredSession`, removing the `iOS 11` availability check. 
- Remove the `#available(iOS 11.0, *)` branch in `KeyboardAdaptable` and always use `window.safeAreaInsets` when adjusting view height for keyboard appearance. 
- Simplify QR generation in `QRGenerator` to always use `CIFilter.qrCodeGenerator()` (iOS 13+ path) and remove the legacy `CIQRCodeGenerator` branch. 
- Always assign `layer.cornerCurve = .continuous` in `View+Extension` without the iOS 13 availability check. 
- Remove `@available(iOS 9.0, *)` and inline availability checks and fallbacks for `addSomeBorders` usages in `UIView+ViewStylable` and `UIView+Borders`, calling `addSomeBorders` directly. 

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979050ace94832ca3b22af49890dc82)