### PR TITLE
Eliminar anotaciones `@available` redundantes

### DIFF
--- a/Sources/GIGLibrary/GIGUtils/ActionSheet/ActionSheet.swift
+++ b/Sources/GIGLibrary/GIGUtils/ActionSheet/ActionSheet.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 8.0, *)
 open class ActionSheet: AlertController {
     
     public override init(title: String, message: String) {

--- a/Sources/GIGLibrary/GIGUtils/AlertController/AlertController.swift
+++ b/Sources/GIGLibrary/GIGUtils/AlertController/AlertController.swift
@@ -9,7 +9,6 @@
 import Foundation
 import UIKit
 
-@available(iOS 8.0, *)
 open class AlertController: NSObject, AlertInterface {
     
     var alert: UIAlertController

--- a/Sources/GIGLibrary/GIGUtils/TextView/ExpandableTextView/ExpandableTextView.swift
+++ b/Sources/GIGLibrary/GIGUtils/TextView/ExpandableTextView/ExpandableTextView.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 9.0, *)
 open class ExpandableTextView: UIView {
     
     // MARK: IBOutlet


### PR DESCRIPTION
### Motivation
- Eliminar las anotaciones `@available(iOS 8.0, *)` y `@available(iOS 9.0, *)` en APIs que son redundantes ahora que el proyecto tiene soporte mínimo iOS 16+.

### Description
- Se quitaron las anotaciones en `Sources/GIGLibrary/GIGUtils/ActionSheet/ActionSheet.swift`, `Sources/GIGLibrary/GIGUtils/AlertController/AlertController.swift` y `Sources/GIGLibrary/GIGUtils/TextView/ExpandableTextView/ExpandableTextView.swift`, y se revisó el `README.md` para confirmar que no declara soporte para iOS anteriores.

### Testing
- No se ejecutaron pruebas automatizadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979051028d4832c939964d56e92b5c8)