### PR TITLE
Eliminar @available redundantes y simplificar Keychain para iOS 9+

### DIFF
--- a/Sources/GIGLibrary/KeychainStore/KeychainConstants.swift
+++ b/Sources/GIGLibrary/KeychainStore/KeychainConstants.swift
@@ -49,12 +49,7 @@ struct KeychainConstants {
 
     /** Other Constants */
 
-    @available(iOS, introduced: 8.0, deprecated: 9.0, message: "Use a UseAuthenticationUI instead.")
-    static let UseNoAuthenticationUI = String(kSecUseNoAuthenticationUI)
-    @available(iOS 9.0, *)
     static let UseAuthenticationUI = String(kSecUseAuthenticationUI)
-    @available(iOS 9.0, *)
     static let UseAuthenticationContext = String(kSecUseAuthenticationContext)
-    @available(iOS 9.0, *)
     static let UseAuthenticationUIFail = String(kSecUseAuthenticationUIFail)
 }

--- a/Sources/GIGLibrary/KeychainStore/KeychainOptions.swift
+++ b/Sources/GIGLibrary/KeychainStore/KeychainOptions.swift
@@ -45,10 +45,8 @@ extension KeychainOptions {
             query[KeychainConstants.AttributeSynchronizable] = self.synchronizable ? kCFBooleanTrue : kCFBooleanFalse
         }
 
-        if #available(iOS 9.0, *) {
-            if let authenticationContext = self.authenticationContext {
-                query[KeychainConstants.UseAuthenticationContext] = authenticationContext
-            }
+        if let authenticationContext = self.authenticationContext {
+            query[KeychainConstants.UseAuthenticationContext] = authenticationContext
         }
         return query
     }

--- a/Sources/GIGLibrary/KeychainStore/KeychainStore.swift
+++ b/Sources/GIGLibrary/KeychainStore/KeychainStore.swift
@@ -213,11 +213,7 @@ open class KeychainStore {
     public func set(_ value: Data, key: String, ignoringAttributeSynchronizable: Bool = true) throws {
         var query = self.options.query(ignoringAttributeSynchronizable: ignoringAttributeSynchronizable)
         query[KeychainConstants.AttributeAccount] = key
-        if #available(iOS 9.0, *) {
-            query[KeychainConstants.UseAuthenticationUI] = KeychainConstants.UseAuthenticationUIFail
-        } else {
-            query[KeychainConstants.UseNoAuthenticationUI] = kCFBooleanTrue
-        }
+        query[KeychainConstants.UseAuthenticationUI] = KeychainConstants.UseAuthenticationUIFail
 
         var status = SecItemCopyMatching(query as CFDictionary, nil)
         switch status {
@@ -230,14 +226,9 @@ open class KeychainStore {
 
             self.options.attributes.forEach { attributes.updateValue($1, forKey: $0) }
 
-            if status == errSecInteractionNotAllowed && floor(NSFoundationVersionNumber) <= floor(NSFoundationVersionNumber_iOS_8_0) {
-                try self.remove(key)
-                try self.set(value, key: key)
-            } else {
-                status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
-                if status != errSecSuccess {
-                    throw self.securityError(status: status)
-                }
+            status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+            if status != errSecSuccess {
+                throw self.securityError(status: status)
             }
         case errSecItemNotFound:
             var (attributes, error) = self.options.attributes(key: key, value: value)
@@ -324,11 +315,7 @@ open class KeychainStore {
         query[KeychainConstants.AttributeAccount] = key
 
         if withoutAuthenticationUI {
-            if #available(iOS 9.0, *) {
-                query[KeychainConstants.UseAuthenticationUI] = KeychainConstants.UseAuthenticationUIFail
-            } else {
-                query[KeychainConstants.UseNoAuthenticationUI] = kCFBooleanTrue
-            }
+            query[KeychainConstants.UseAuthenticationUI] = KeychainConstants.UseAuthenticationUIFail
         }
         
         let status = SecItemCopyMatching(query as CFDictionary, nil)


### PR DESCRIPTION
### Motivation
- Modernizar y simplificar el manejo del Keychain eliminando ramas legadas de iOS 8/9 para mantener una única ruta de ejecución moderna.
- Quitar anotaciones de disponibilidad redundantes ahora que el soporte mínimo es moderno y aplicar siempre las opciones de autenticación disponibles.

### Description
- Removed `UseNoAuthenticationUI` and `@available(iOS 9.0, *)` annotations in `Sources/GIGLibrary/KeychainStore/KeychainConstants.swift` and kept `UseAuthenticationUI`, `UseAuthenticationContext` y `UseAuthenticationUIFail` como constantes accesibles sin guardas de disponibilidad.
- Changed `Sources/GIGLibrary/KeychainStore/KeychainOptions.swift` to always add `UseAuthenticationContext` to the query when `authenticationContext` is present by removing the `#available(iOS 9.0, *)` guard and using `query[KeychainConstants.UseAuthenticationContext]` directly.
- Updated `Sources/GIGLibrary/KeychainStore/KeychainStore.swift` to always set `UseAuthenticationUI` to `UseAuthenticationUIFail` when checking/setting items and removed the iOS 8 fallback around `SecItemUpdate`, simplifying the update/add logic and removing uses of `UseNoAuthenticationUI`.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697904f2cbe0832cbca69a9e19fc71b5)