### PR TITLE
Eliminar @available(iOS 9.0, *) de authenticationContext en KeychainStore

### DIFF
--- a/Sources/GIGLibrary/KeychainStore/KeychainStore.swift
+++ b/Sources/GIGLibrary/KeychainStore/KeychainStore.swift
@@ -46,7 +46,6 @@ open class KeychainStore {
         return self.options.authenticationPrompt
     }
 
-    @available(iOS 9.0, *)
     public var authenticationContext: LAContext? {
         return self.options.authenticationContext as? LAContext
     }
@@ -134,7 +133,6 @@ open class KeychainStore {
         return KeychainStore(options)
     }
 
-    @available(iOS 9.0, *)
     public func authenticationContext(_ authenticationContext: LAContext) -> KeychainStore {
         var options = self.options
         options.authenticationContext = authenticationContext


### PR DESCRIPTION
### Motivation
- Se elimina la restricción de disponibilidad iOS 9 en las APIs de autenticación para permitir el uso de `authenticationContext` sin anotaciones de disponibilidad en `Sources/GIGLibrary/KeychainStore/KeychainStore.swift`.

### Description
- Se eliminaron las anotaciones `@available(iOS 9.0, *)` de la propiedad `authenticationContext` y del método `authenticationContext(_:)` en `Sources/GIGLibrary/KeychainStore/KeychainStore.swift`, y se comprobó que no existan usos condicionados a iOS 9+ para estas APIs en el mismo archivo.

### Testing
- No se ejecutaron pruebas automatizadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979e310a040832cac660e5b0a99f392)