### PR TITLE
Simplificar obtención de la ventana activa

### DIFF
--- a/Sources/GIGLibrary/GIGUtils/Application/UIApplication+Window.swift
+++ b/Sources/GIGLibrary/GIGUtils/Application/UIApplication+Window.swift
@@ -10,21 +10,17 @@ import UIKit
 
 extension UIApplication {
     var activeWindow: UIWindow? {
-        if #available(iOS 13.0, *) {
-            let activeScenes = connectedScenes
-                .filter { $0.activationState == .foregroundActive }
-                .compactMap { $0 as? UIWindowScene }
-            let activeWindows = activeScenes.flatMap { $0.windows }
-            if let window = activeWindows.first(where: { $0.isKeyWindow }) ?? activeWindows.first {
-                return window
-            }
-
-            let windows = connectedScenes
-                .compactMap { $0 as? UIWindowScene }
-                .flatMap { $0.windows }
-            return windows.first { $0.isKeyWindow } ?? windows.first
+        let activeScenes = connectedScenes
+            .filter { $0.activationState == .foregroundActive }
+            .compactMap { $0 as? UIWindowScene }
+        let activeWindows = activeScenes.flatMap { $0.windows }
+        if let window = activeWindows.first(where: { $0.isKeyWindow }) ?? activeWindows.first {
+            return window
         }
 
-        return keyWindow
+        let windows = connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+        return windows.first { $0.isKeyWindow } ?? windows.first
     }
 }


### PR DESCRIPTION
### Motivation
- Eliminar la rama legacy de disponibilidad de iOS y el fallback a `keyWindow` para usar únicamente la selección basada en `connectedScenes`.

### Description
- En `Sources/GIGLibrary/GIGUtils/Application/UIApplication+Window.swift` se eliminó el `if #available(iOS 13.0, *)` y el `return keyWindow`, dejando la lógica que filtra `connectedScenes` por `UIWindowScene` y selecciona la ventana activa entre sus `windows`.

### Testing
- No se ejecutaron pruebas automatizadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979e3142c18832ca0c7b5bedd08aaf1)