### PR TITLE
Agregar anotaciones @Sendable a helpers de dispatch

### DIFF
--- a/Sources/GIGLibrary/GIGUtils/Dispatch.swift
+++ b/Sources/GIGLibrary/GIGUtils/Dispatch.swift
@@ -9,15 +9,15 @@
 
 import Foundation
 
-public func gig_dispatch_background(_ code: @escaping () -> Void) {
+public func gig_dispatch_background(_ code: @Sendable @escaping () -> Void) {
 	DispatchQueue.global(qos: DispatchQoS.QoSClass.userInitiated).async(execute: code)
 }
 
-public func gig_dispatch_main(_ code: @escaping () -> Void) {
+public func gig_dispatch_main(_ code: @Sendable @escaping () -> Void) {
 	DispatchQueue.main.async(execute: code) 
 }
 
-public func gig_dispatch_main_after(_ seconds: UInt64, code: @escaping () -> Void) {
+public func gig_dispatch_main_after(_ seconds: UInt64, code: @Sendable @escaping () -> Void) {
 	let popTime = DispatchTime.now() + Double((Int64)(seconds * NSEC_PER_SEC)) / Double(NSEC_PER_SEC)
 	DispatchQueue.main.asyncAfter(deadline: popTime, execute: code)
 }


### PR DESCRIPTION
### Motivation
- Mejorar la seguridad de concurrencia al requerir que los closures pasados a los helpers de dispatch sean `@Sendable`, evitando capturas no seguras al usarlos desde distintos hilos.

### Description
- Se actualizaron las firmas de `gig_dispatch_background`, `gig_dispatch_main` y `gig_dispatch_main_after` para usar `@Sendable @escaping () -> Void` y se revisaron los call sites con `rg "gig_dispatch_"`, no encontrando usos adicionales fuera de las definiciones.

### Testing
- No se ejecutaron pruebas automatizadas en esta rama.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a28a7bfd0832cb9d9c3b7a2447f1c)