### PR TITLE
Asegurar acceso MainActor en ImageDownloader

### DIFF
--- a/Sources/GIGLibrary/GIGUtils/Image/ImageDownloader.swift
+++ b/Sources/GIGLibrary/GIGUtils/Image/ImageDownloader.swift
@@ -60,36 +60,42 @@ struct ImageDownloader {
         }
         let requestedBaseURL = request.baseURL
         request.fetch { response in
-            switch response.status {
-            case .success:
-                guard let image = try? response.image() else {
-                    LogWarn("While downloading the image, the body was empty or the image type was not recognized.")
-                    self.downloadNext()
-                    return
-                }
-                let width = view.width() * UIScreen.main.scale
-                let height = view.height() * UIScreen.main.scale
-                DispatchQueue(label: "com.gigigo.imagedownloader", qos: .background).async {
-                    var finalImage = image
-                    if let resized = image.imageProportionally(with: CGSize(width: width, height: height)) {
-                        finalImage = resized
-                    }
-                    Task { @MainActor in
-                        if let currentRequest = ImageDownloader.queue[view], requestedBaseURL == currentRequest.baseURL {
-                            self.setAnimated(image: finalImage, in: view)
-                        }
-                        if let index = ImageDownloader.queue.index(forKey: view) {
-                            ImageDownloader.queue.remove(at: index)
-                            ImageDownloader.images.updateValue(finalImage, forKey: requestedBaseURL)
-                        }
-                        self.downloadNext()
-                    }
-                }
-            default:
-                LogError(response.error)
-                self.downloadNext()
-                
+            Task { @MainActor in
+                self.handleResponse(response, view: view, requestedBaseURL: requestedBaseURL)
             }
+        }
+    }
+
+    private func handleResponse(_ response: Response, view: UIImageView, requestedBaseURL: String) {
+        switch response.status {
+        case .success:
+            guard let image = try? response.image() else {
+                LogWarn("While downloading the image, the body was empty or the image type was not recognized.")
+                self.downloadNext()
+                return
+            }
+            let width = view.width() * UIScreen.main.scale
+            let height = view.height() * UIScreen.main.scale
+            let targetSize = CGSize(width: width, height: height)
+            Task.detached(priority: .background) {
+                var finalImage = image
+                if let resized = image.imageProportionally(with: targetSize) {
+                    finalImage = resized
+                }
+                await MainActor.run {
+                    if let currentRequest = ImageDownloader.queue[view], requestedBaseURL == currentRequest.baseURL {
+                        self.setAnimated(image: finalImage, in: view)
+                    }
+                    if let index = ImageDownloader.queue.index(forKey: view) {
+                        ImageDownloader.queue.remove(at: index)
+                        ImageDownloader.images.updateValue(finalImage, forKey: requestedBaseURL)
+                    }
+                    self.downloadNext()
+                }
+            }
+        default:
+            LogError(response.error)
+            self.downloadNext()
         }
     }
     


### PR DESCRIPTION
### Motivation
- Evitar condiciones de carrera y asegurar que todas las lecturas/escrituras de los diccionarios compartidos `queue`, `stack` e `images`, así como las actualizaciones de UI en `UIImageView`, se realicen en el `MainActor`.
- Mantener el trabajo costoso de redimensionado de imágenes fuera del hilo principal para no bloquear la UI.

### Description
- Routee el callback de `request.fetch` a `Task { @MainActor in ... }` y extraje la lógica en un nuevo método `handleResponse(_:view:requestedBaseURL:)` para centralizar el manejo de la respuesta.
- Mantengo el redimensionado de imágenes en `Task.detached(priority: .background)` y luego uso `await MainActor.run` para ejecutar la actualización de UI (`setAnimated`) y las modificaciones a `ImageDownloader.queue` y `ImageDownloader.images`.
- Eliminé el uso anterior de una `DispatchQueue` para el procesamiento en background y simplifiqué el flujo para asegurar que `downloadNext()` siempre se invoque desde el contexto correcto.

### Testing
- No se ejecutaron pruebas automatizadas para este cambio.
- El cambio fue validado manualmente a nivel de revisión de código para garantizar el aislamiento de actor y la preservación del comportamiento previo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a28ae31fc832c9e710200a7df7d95)