### PR TITLE
Traducir AGENTS.md al inglés

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS
+
+## Minimum platform
+- iOS 16+.
+
+## Swift version
+- Swift 6.2.
+
+## Concurrency approach (Approachable Concurrency)
+- Prioritize modern APIs with `async/await` and concurrency-safe types.
+- Avoid blocking threads; use structured tasks and proper isolation.
+- Keep compatibility with iOS 16+ and document any concurrency-impacting decisions.
+
+### Practical rules
+- Prefer `async` over callbacks whenever possible.
+- Use `@MainActor` when UI state or dependencies require it.
+- Limit the scope of `Task` and document the reason for unstructured tasks.
+
+## Testing style
+- Apply BDD: test observable behavior rather than implementation details.
+- Keep comprehensive tests that cover happy paths, errors, and relevant edges.
+- Use the `Testing` framework with suites and descriptive names, following Given/When/Then.
+
+## Code conventions
+- Keep names clear, consistent, and specific.
+- Prioritize readability and avoid unnecessary abbreviations.
+- Document non-obvious decisions with brief, precise comments.
+
+## Workflow (tests, commits/PRs)
+- Run relevant tests before finishing changes.
+- Create atomic commits with clear, descriptive messages.
+- Open PRs with a concise summary and sufficient context.


### PR DESCRIPTION
### Motivation
- Traducir las pautas del repositorio en `AGENTS.md` al inglés para cumplir la solicitud de tener el documento en inglés y mantener los requisitos de plataforma (`iOS 16+`) y versión (`Swift 6.2`).

### Description
- Reemplacé el contenido en español por su equivalente en inglés en `AGENTS.md`, preservando las secciones sobre concurrency, practical rules, testing style, code conventions y workflow. 

### Testing
- No se ejecutaron pruebas automatizadas porque el cambio es únicamente de documentación (doc-only change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a39307a18832c8561a7306cd1409b)