### PR TITLE
Alinear logging de `fetch` async y simplificar helpers de `Response`

### DIFF
--- a/Sources/GIGLibrary/SwiftNetwork/Request.swift
+++ b/Sources/GIGLibrary/SwiftNetwork/Request.swift
@@ -67,10 +67,46 @@ public class Request: Selfie, @unchecked Sendable {
 
     // Async APIs return Response and never throw; callers should inspect Response.status and Response.error.
     public func fetch() async -> Response {
-        await withCheckedContinuation { continuation in
-            fetch { response in
-                continuation.resume(returning: response)
-            }
+        guard let request = self.buildRequest() else {
+            return Response.invalidURL()
+        }
+        guard self.reachability.isReachable() else {
+            return Response.noInternet()
+        }
+        self.request = request
+        self.logRequest()
+        self.cancel()
+
+        let session = self.configuredSession(applyCache: true)
+        defer {
+            session.finishTasksAndInvalidate()
+        }
+
+        if Task.isCancelled {
+            self.logRequestError(message: "Request cancelled before execution.")
+            return Response.cancelled()
+        }
+
+        do {
+            let (data, urlResponse) = try await session.data(for: request)
+            let response = Response(
+                successData: data,
+                response: urlResponse,
+                standardType: self.standardType,
+                networkLogManager: self.networkLogManager
+            )
+            self.logIfVerbose(response)
+            return response
+        } catch is CancellationError {
+            self.logRequestError(message: "Request cancelled during execution.")
+            return Response.cancelled()
+        } catch {
+            self.logRequestError(message: error.localizedDescription)
+            return Response(
+                error: error,
+                standardType: self.standardType,
+                networkLogManager: self.networkLogManager
+            )
         }
     }
 
@@ -188,7 +224,7 @@ public class Request: Selfie, @unchecked Sendable {
     public func fetch(completionHandler: @escaping CompletionHandler) {
 		guard let request = self.buildRequest() else {
             Task { @MainActor in
-                completionHandler(self.invalidRequestResponse(standardType: self.standardType))
+                completionHandler(Response.invalidURL())
             }
             return
         }
@@ -228,7 +264,7 @@ public class Request: Selfie, @unchecked Sendable {
     public func fetch(withDownloadUrlFile: URL, completionHandler: @escaping CompletionHandler) {
         guard let request = self.buildRequest() else {
             Task { @MainActor in
-                completionHandler(self.invalidRequestResponse(standardType: .basic))
+                completionHandler(Response.invalidURL())
             }
             return
         }
@@ -293,7 +329,7 @@ public class Request: Selfie, @unchecked Sendable {
         
         guard var request = self.buildRequest(), let boundary = self.generateBoundary() else {
             Task { @MainActor in
-                completionHandler(self.invalidRequestResponse(standardType: self.standardType))
+                completionHandler(Response.invalidURL())
             }
             return
         }
@@ -362,9 +398,15 @@ public class Request: Selfie, @unchecked Sendable {
         return URLSession(configuration: configuration, delegate: self as? URLSessionDelegate, delegateQueue: nil)
     }
 
-    private func invalidRequestResponse(standardType: StandardType) -> Response {
-        let error = URLError(.badURL)
-        return Response(data: nil, response: nil, error: error, standardType: standardType, networkLogManager: self.networkLogManager)
+    private func logIfVerbose(_ response: Response) {
+        if self.verbose {
+            response.logResponse(self.logInfo)
+        }
+    }
+
+    private func logRequestError(message: String) {
+        guard self.verbose else { return }
+        self.networkLogManager.log(message, info: self.logInfo)
     }
 	
 	fileprivate func buildRequest() -> URLRequest? {

--- a/Sources/GIGLibrary/SwiftNetwork/Response.swift
+++ b/Sources/GIGLibrary/SwiftNetwork/Response.swift
@@ -72,12 +72,32 @@ public class Response: Selfie, @unchecked Sendable {
 			self.status = self.parseError(error: self.error)
 		}
 	}
+
+    convenience init(successData: Data?, response: URLResponse?, standardType: StandardType = .gigigo, networkLogManager: NetworkLogManaging = DefaultNetworkLogManager()) {
+        self.init(data: successData, response: response, error: nil, standardType: standardType, networkLogManager: networkLogManager)
+    }
+
+    convenience init(error: Error?, standardType: StandardType = .gigigo, networkLogManager: NetworkLogManaging = DefaultNetworkLogManager()) {
+        self.init(data: nil, response: nil, error: error, standardType: standardType, networkLogManager: networkLogManager)
+    }
 	
     // MARK: - Instance methods
     
     class func noInternet() -> Response {
         let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, message: "No Internet")
         let response = Response(data: nil, response: nil, error: error)
+        return response
+    }
+
+    class func invalidURL() -> Response {
+        let error = URLError(.badURL)
+        let response = Response(error: error)
+        return response
+    }
+
+    class func cancelled() -> Response {
+        let error = URLError(.cancelled)
+        let response = Response(error: error)
         return response
     }
 	


### PR DESCRIPTION
### Motivation
- Evitar duplicación y claridad en los casos de error para las APIs async y basadas en callbacks cambiando los helpers de `Response` a versiones simples sin parámetros.
- Registrar errores de construcción/ejecución de la request desde la propia `Request` en lugar de delegarlo a un `Response` ad-hoc para mantener responsabilidades claras.
- Mantener el logging detallado de respuestas exitosas sin mezclarlo con el logging de errores de request.

### Description
- Cambié `Response.invalidURL(...)` y `Response.cancelled(...)` a helpers sin parámetros como `Response.invalidURL()` y `Response.cancelled()` en `Sources/GIGLibrary/SwiftNetwork/Response.swift` y añadí los initializers `init(successData:response:)` e `init(error:)` para conveniencia.
- Reescribí `public func fetch() async -> Response` en `Sources/GIGLibrary/SwiftNetwork/Request.swift` para construir el `URLRequest` al inicio, comprobar `reachability`, usar `configuredSession` y `await session.data(for:)`, retornando `Response.success`, `Response.cancelled()` o `Response(error:)` según corresponda.
- Reemplacé las rutas basadas en callbacks (`fetch(completionHandler:)`, `fetch(withDownloadUrlFile:)`, `upload(...)`) para usar `Response.invalidURL()` y simplifiqué helpers redundantes eliminando `invalidRequestResponse`.
- Añadí `private func logRequestError(message: String)` y mantuve `private func logIfVerbose(_:)` para separar el logging de errores de request del logging de respuestas exitosas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a508c23a8832c86928b19a1c2fb4e)