### PR TITLE
Eliminar `@unchecked Sendable` de `Request` y `Response`

### DIFF
--- a/Sources/GIGLibrary/SwiftNetwork/Request.swift
+++ b/Sources/GIGLibrary/SwiftNetwork/Request.swift
@@ -40,7 +40,7 @@ public struct FileUploadData {
     }
 }
 
-public class Request: Selfie, @unchecked Sendable {
+public class Request: Selfie {
 	
     public var method: HTTPMethod
     public var baseURL: String

--- a/Sources/GIGLibrary/SwiftNetwork/Response.swift
+++ b/Sources/GIGLibrary/SwiftNetwork/Response.swift
@@ -25,7 +25,7 @@ public enum ResponseStatus {
 	case untrustedCertificate
 }
 
-public class Response: Selfie, @unchecked Sendable {
+public class Response: Selfie {
 	
 	public var status: ResponseStatus
 	public var statusCode: Int


### PR DESCRIPTION
### Motivation
- Tras el refactor a APIs `async/await`, se determinó que la conformidad `@unchecked Sendable` ya no es necesaria porque instancias de `Request` y `Response` no se comparten concurrentemente de forma insegura y la mutabilidad interna está contenida en propiedades privadas o en contextos creados por el llamador.

### Description
- Removed `@unchecked Sendable` from `Request` in `Sources/GIGLibrary/SwiftNetwork/Request.swift` and from `Response` in `Sources/GIGLibrary/SwiftNetwork/Response.swift` to avoid declaring unchecked concurrency guarantees without justification.

### Testing
- No se ejecutaron pruebas automatizadas porque las validaciones de test deben realizarse en entornos macOS y no estuvieron disponibles en este entorno.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b7e499100832c91ee6a1145900c09)