### PR TITLE
Quitar comentario sobre @MainActor en Response.image() y marcar APIs async de Request como @concurrent

### DIFF
--- a/Sources/GIGLibrary/SwiftNetwork/Request.swift
+++ b/Sources/GIGLibrary/SwiftNetwork/Request.swift
@@ -64,6 +64,7 @@ public class Request: Selfie {
     private let session: URLSession?
 
     // Async APIs return Response and never throw; callers should inspect Response.status and Response.error.
+    @concurrent
     public func fetch() async -> Response {
         guard let request = self.buildRequest() else {
             return Response.invalidURL()
@@ -108,6 +109,7 @@ public class Request: Selfie {
         }
     }
 
+    @concurrent
     public func fetch(downloadTo fileURL: URL) async -> Response {
         guard let request = self.buildRequest() else {
             return Response.invalidURL()
@@ -156,6 +158,7 @@ public class Request: Selfie {
         }
     }
 
+    @concurrent
     public func upload(files: [FileUploadData], params: [String: Any]) async -> Response {
         guard var request = self.buildRequest(), let boundary = self.generateBoundary() else {
             return Response.invalidURL()


### PR DESCRIPTION
### Motivation
- Evitar que las APIs `async` de red hereden el contexto de `MainActor` cuando se llaman desde la UI para forzar su ejecución en background en operaciones costosas como `Request.fetch()`/`upload()` y conservar `@MainActor` en `Response.image()` por su dependencia de UIKit. 
- Eliminar un comentario inline redundante sobre `@MainActor` en `Response.image()` tras el feedback de revisión.

### Description
- Añadido `@concurrent` a las funciones `async` `fetch()`, `fetch(downloadTo:)` y `upload(files:params:)` en `Sources/GIGLibrary/SwiftNetwork/Request.swift` para permitir su ejecución fuera del `MainActor` heredado. 
- Conservado el atributo `@MainActor` en `Sources/GIGLibrary/SwiftNetwork/Response.swift` para la función `image()` y eliminado el comentario inline que explicaba ese requisito. 
- Los cambios están limitados a `Request.swift` y `Response.swift` sin modificar otras APIs.

### Testing
- No se ejecutaron pruebas automatizadas porque la validación de tests requiere un entorno macOS y no estuvo disponible en esta sesión.
- Se verificó localmente la edición del archivo para confirmar la eliminación del comentario y la presencia de los atributos aplicados, sin ejecutar suites de prueba.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c82e6dc54832c8bc1958d90b8f71d)