### PR TITLE
Agregar ejemplos de uso async al README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,73 @@ dependencies: [
 	- SwiftNetwork: Swift classes to manage gigigo's requestst. Standard Gigigo JSON is parsed by default.
 	- GIGUtils: a lot of extensions on foundation classes.
 	- GIGScanner: QR scanner using native iOS API
+
+## Async usage examples
+
+### Simple fetch
+
+```swift
+let request = Request(
+    method: .get,
+    baseUrl: "https://api.example.com",
+    endpoint: "/v1/profile",
+    headers: ["Authorization": "Bearer token"]
+)
+
+let response = await request.fetch()
+if response.status == .success {
+    let profile = try? response.json()
+    print("Profile JSON: \(String(describing: profile))")
+} else {
+    print("Request failed with status: \(response.status)")
+}
+```
+
+### Download to file
+
+```swift
+let request = Request(
+    method: .get,
+    baseUrl: "https://cdn.example.com",
+    endpoint: "/files/report.pdf"
+)
+
+let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+let destinationURL = documentsURL.appendingPathComponent("report.pdf")
+
+let response = await request.fetch(downloadTo: destinationURL)
+if response.status == .success {
+    print("File downloaded to: \(destinationURL.path)")
+} else {
+    print("Download failed with status: \(response.status)")
+}
+```
+
+### Multipart upload
+
+```swift
+let imageData = Data() // Provide real file data.
+let file = FileUploadData(
+    data: imageData,
+    mimeType: "image/jpeg",
+    filename: "avatar.jpg",
+    name: "avatar"
+)
+
+let request = Request(
+    method: .post,
+    baseUrl: "https://api.example.com",
+    endpoint: "/v1/uploads"
+)
+
+let response = await request.upload(
+    files: [file],
+    params: ["userId": "12345"]
+)
+
+if response.status == .success {
+    print("Upload completed")
+} else {
+    print("Upload failed with status: \(response.status)")
+}
+```


### PR DESCRIPTION
### Motivation

- Documentar el uso de las nuevas APIs `async` para operaciones de red comunes usando la librería interna.
- Proveer ejemplos claros y listos para copiar que cubran fetch simple, descarga a archivo y subida multipart.

### Description

- Se añadió una sección `Async usage examples` en `README.md` con tres ejemplos: `Request.fetch()`, `fetch(downloadTo:)` y `upload(files:params:)`.
- Los snippets muestran llamadas `await` y manejo básico de `Response` para comprobar `response.status` y acceder a `response.json()` o rutas de archivo.
- El código de ejemplo está en inglés y alineado con la API asíncrona introducida en el paquete.

### Testing

- No se ejecutaron pruebas automatizadas porque el cambio es puramente de documentación y las validaciones de test deben correrse en macOS.
- La modificación fue verificada localmente revisando el `README.md` actualizado y la consistencia de las firmas usadas en los ejemplos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69807c26cae0832c8e9a2a17e49d54d8)