### PR TITLE
Add Claude Code documentation via .claude/rules/

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,112 @@
+# Architecture
+
+## Source Tree
+
+```
+Sources/GIGLibrary/
+├── SwiftNetwork/
+│   ├── Request.swift
+│   ├── Response.swift
+│   ├── FetchDecodableError.swift
+│   ├── ReachabilityWrapper.swift
+│   └── Helpers/
+│       ├── NetworkLogManaging.swift
+│       ├── RequestLogFormatter.swift
+│       └── ResponseLogFormatter.swift
+├── KeychainStore/              # 7 files
+├── GIGScanner/                 # 2 files
+├── RequestLogInfo.swift
+├── Libs/External/Reachability.swift
+└── GIGUtils/
+    ├── ActionSheet/
+    ├── AlertController/
+    ├── Application/            # UIApplication+Window.swift
+    ├── Bundle/
+    ├── Color/
+    ├── CoreData/
+    ├── Date/
+    ├── Dispatch.swift
+    ├── Error/
+    ├── GIGIOSVersion.swift
+    ├── Image/
+    ├── InfoPlist.swift
+    ├── Instantiator.swift
+    ├── Keyboard/
+    ├── Locale/
+    ├── Log/
+    ├── MultiDelegable.swift
+    ├── QRGenerator/
+    ├── Selfie.swift
+    ├── Storyboard/
+    ├── String/
+    ├── Style/
+    │   ├── Stylable.swift
+    │   ├── StylableExtensions/   # UIButton, UILabel, UITextField, UITextView, UIView, UIString
+    │   ├── Styles/               # ButtonStyle, LabelStyle, TextFieldStyle, TextViewStyle, ViewStyle, TextStyle
+    │   └── UIKitExtensions/
+    ├── SwiftJson/Json.swift
+    ├── TextView/
+    │   ├── ExpandableTextView/
+    │   └── HyperlinkTextView/
+    └── View/
+
+Tests/GIGLibraryTests/
+├── GIGUtils/                   # Date, JSON, Style, StyledString tests
+└── SwiftNetwork/
+    ├── Fakes/
+    │   ├── Fixtures/            # JSON fixtures (SPM resource bundle)
+    │   ├── FixtureLoader.swift
+    │   └── ResponseFakes.swift
+    ├── Mocks/
+    │   ├── NetworkLogManagerSpy.swift
+    │   └── RequestMocks.swift
+    ├── IntegrationTests.swift
+    ├── RequestTests.swift
+    ├── ResponseTests.swift
+    └── TestModels.swift
+```
+
+## Module Overview
+
+| Module | Purpose |
+|--------|---------|
+| `SwiftNetwork` | Async HTTP client: Request, Response, multipart upload, file download |
+| `KeychainStore` | Fluent API wrapper around Apple Security framework |
+| `GIGScanner` | QR code scanning via AVCaptureSession |
+| `GIGUtils/Log` | LogManager singleton with per-module levels and styles |
+| `GIGUtils/SwiftJson` | JSON wrapper with dot-notation subscript traversal |
+| `GIGUtils/Style` | Protocol-based UIKit styling (Stylable, ViewStylable) |
+
+## Notable Utilities
+
+| File | Purpose |
+|------|---------|
+| `Selfie.swift` | `description` via Mirror reflection; Request/Response conform |
+| `Instantiator.swift` | `Instantiable` protocol for storyboard VC instantiation (`@MainActor`) |
+| `MultiDelegable.swift` | Broadcast to multiple delegates |
+| `Dispatch.swift` | GCD helpers (`@Sendable`-annotated) |
+| `UIApplication+Window.swift` | Active window lookup helper |
+| `ImageDownloader.swift` | Async image download with caching (`@MainActor`) |
+| `QRGenerator.swift` | Generates UIImage QR codes from strings |
+| `KeyboardAdaptable.swift` | Protocol for keyboard show/hide layout adjustment |
+| `ExpandableTextView.swift` | Auto-expanding UITextView |
+| `HyperlinkTextView.swift` | UITextView with tappable hyperlinks |
+
+## Public API Constants
+
+```swift
+public let kGIGNetworkErrorDomain = "com.gigigo.network"
+public let kGIGNetworkErrorMessage = "GIGNETWORK_ERROR_MESSAGE"
+```
+
+## Adding a New Utility
+
+1. Create `Sources/GIGLibrary/GIGUtils/<FeatureName>/<FeatureName>.swift`
+2. SPM auto-discovers sources — no `Package.swift` change needed
+3. Add tests under `Tests/GIGLibraryTests/GIGUtils/`
+
+## Adding a New Network Helper
+
+1. Add source to `Sources/GIGLibrary/SwiftNetwork/Helpers/`
+2. Keep formatters pure: static methods on enums, no state
+3. Inject via `NetworkLogManaging` for logging in tests

--- a/.claude/rules/concurrency.md
+++ b/.claude/rules/concurrency.md
@@ -1,0 +1,28 @@
+# Concurrency
+
+Swift 6.2 with `StrictConcurrency` and `ApproachableConcurrency` enabled. All new code must compile warning-free under these settings.
+
+## Rules
+
+- **Prefer `async/await`** over completion handlers for all new code
+- Use `@MainActor` for any code accessing UI state, `UIScreen`, or UIKit components
+- Annotate closures and types with `@Sendable` / `Sendable` when crossing concurrency boundaries
+- Limit unstructured `Task { }` usage; document any that exist with a comment explaining why structured concurrency is not possible
+- Do not use `@unchecked Sendable` lightly — only where isolation is guaranteed by design (e.g., `Response` which is always written before crossing a boundary)
+
+## Async method annotation
+
+Public async methods use `@concurrent` to opt into unstructured execution:
+
+```swift
+@concurrent
+public func fetch() async -> Response { ... }
+```
+
+## Cancellation
+
+Support `Task` cancellation via `withTaskCancellationHandler`. Check `Task.isCancelled` before starting expensive work.
+
+## GCD
+
+GCD helpers in `Dispatch.swift` are annotated `@Sendable`. Prefer `async/await` over `DispatchQueue.async` in new code.

--- a/.claude/rules/keychain.md
+++ b/.claude/rules/keychain.md
@@ -1,0 +1,65 @@
+---
+paths:
+  - "Sources/GIGLibrary/KeychainStore/**"
+---
+
+# KeychainStore
+
+Fluent-API wrapper around Apple's Security framework. All throwing methods surface `Status` errors.
+
+## Initializers
+
+```swift
+KeychainStore()                            // uses bundle identifier as service
+KeychainStore(service: "com.example.app")
+KeychainStore(accessGroup: "group.id")
+KeychainStore(service: "...", accessGroup: "...")
+```
+
+## Builder Pattern (returns a new configured instance)
+
+```swift
+let store = KeychainStore()
+    .accessibility(.afterFirstUnlock)
+    .accessibility(.whenPasscodeSetThisDeviceOnly, authenticationPolicy: .biometryAny)
+    .synchronizable(true)
+    .label("My Token")
+    .comment("Auth token")
+    .authenticationPrompt("Confirm identity")
+    .authenticationContext(laContext)
+```
+
+## Read / Write
+
+```swift
+// Throwing API
+try store.set("value", key: "myKey")
+let value: String? = try store.get("myKey")
+let raw: Data?     = try store.getData("myKey")
+try store.remove("myKey")
+try store.removeAll()
+let exists = try store.contains("myKey")
+
+// Non-throwing subscript (swallows errors silently)
+store["myKey"] = "value"
+let s: String? = store["myKey"]
+let d: Data?   = store[data: "myKey"]
+```
+
+## Enumeration
+
+```swift
+store.allKeys()                        // [String] for this service
+KeychainStore.allKeys()                // [(service, key)] across all services
+store.allItems()                       // [[String: Any]]
+KeychainStore.allItems()               // [[String: Any]] across all
+```
+
+## Key Files
+
+`KeychainStore.swift`, `KeychainAccessibility.swift`, `KeychainAuthenticationPolicy.swift`, `KeychainOptions.swift`, `KeychainAttributes.swift`, `KeychainConstants.swift`, `Status.swift`
+
+## Pitfalls
+
+- Throwing methods must be wrapped in `try`/`do-catch`; use subscript accessors when error handling is not critical
+- `setLogValues(forModule:)` in `LogManager` throws if the module is registered twice — call `removeSettingsForModule` before re-registering (unrelated but often paired with Keychain setup)

--- a/.claude/rules/networking.md
+++ b/.claude/rules/networking.md
@@ -1,0 +1,161 @@
+---
+paths:
+  - "Sources/GIGLibrary/SwiftNetwork/**"
+  - "Tests/GIGLibraryTests/SwiftNetwork/**"
+---
+
+# SwiftNetwork
+
+## Request
+
+`public class Request` — builds and fires HTTP requests. All methods are async; no callbacks.
+
+### Public Properties
+
+| Property | Type | Default |
+|----------|------|---------|
+| `method` | `HTTPMethod` | `.get` |
+| `baseURL` | `String` | — |
+| `endpoint` | `String` | — |
+| `headers` | `[String: String]?` | `nil` |
+| `urlParams` | `[String: Any]?` | `nil` |
+| `bodyParams` | `[String: Any]?` | `nil` |
+| `verbose` | `Bool` | `false` |
+| `standardType` | `StandardType` | `.gigigo` |
+| `timeout` | `TimeInterval` | `15.0` |
+
+### Async API
+
+```swift
+// Never throws — check Response.status
+func fetch() async -> Response
+
+// Throws FetchDecodableError
+func fetchDecodable<T: Decodable>() async throws -> T
+
+// Throws NSError on failure
+func fetchVoid() async throws
+
+// Never throws — downloads to disk
+func fetch(downloadTo fileURL: URL) async -> Response
+
+// Never throws — multipart upload
+func upload(files: [FileUploadData], params: [String: Any]) async -> Response
+
+func cancel()
+```
+
+### Initializers
+
+```swift
+// Dictionary body
+Request(method: .post, baseUrl: "https://api.example.com", endpoint: "/items",
+        bodyParams: ["key": "value"])
+
+// Array body
+Request(method: .post, baseUrl: "...", endpoint: "/items",
+        bodyParamsArray: [["id": 1], ["id": 2]])
+
+// Encodable body (type-safe, uses JSONEncoder)
+Request(method: .post, baseUrl: "...", endpoint: "/items", body: myEncodable)
+```
+
+### Automatic Headers
+
+Added unless already present (case-insensitive check):
+- `Accept: application/json` — every request
+- `Content-Type: application/json` — non-GET requests
+
+### StandardType
+
+- `.gigigo` (default): expects `{ "status": true/"OK", "data": {...} }` wrapper; parses `data` field
+- `.basic`: returns the raw JSON directly into `Response.data`
+
+### HTTPMethod
+
+`.get` `.post` `.put` `.delete` `.patch` `.options` `.head` `.trace` `.connect`
+
+### FileUploadData
+
+```swift
+FileUploadData(data: Data, mimeType: String, filename: String, name: String)
+```
+
+---
+
+## Response
+
+`public class Response: @unchecked Sendable`
+
+| Property | Type |
+|----------|------|
+| `status` | `ResponseStatus` |
+| `statusCode` | `Int` |
+| `data` | `JSON?` — parsed body |
+| `body` | `Data?` — raw bytes |
+| `error` | `NSError?` |
+| `url` | `URL?` |
+| `headers` | `[AnyHashable: Any]?` |
+
+Helper methods:
+- `json() throws -> JSON`
+- `image() throws -> UIImage` — **requires `@MainActor`**
+
+Internal factory methods: `noInternet()`, `invalidURL()`, `cancelled()`, `cannotEncodeContentData()`
+
+### ResponseStatus (Sendable)
+
+`.success` `.errorParsingJson` `.sessionExpired` `.timeout` `.noInternet` `.apiError` `.unknownError` `.untrustedCertificate`
+
+### Error Code Mapping
+
+| Code | Status |
+|------|--------|
+| 401, 403 | `.sessionExpired` |
+| -1001 | `.timeout` |
+| -1009 | `.noInternet` |
+| -1202 | `.untrustedCertificate` |
+| 10000–20000 | `.apiError` |
+
+### Gigigo JSON Format
+
+```json
+{ "status": true,  "data": { ... } }
+{ "status": "OK",  "data": { ... } }
+{ "status": false, "error": { "code": 1001, "message": "..." } }
+```
+
+---
+
+## FetchDecodableError
+
+```swift
+case requestFailed(status: ResponseStatus, statusCode: Int, underlying: NSError?)
+case emptyResponseBody(statusCode: Int)
+case decodingFailed(underlying: Error)
+```
+
+---
+
+## NetworkLogManaging
+
+Internal protocol for injectable logging:
+
+```swift
+protocol NetworkLogManaging {
+    func log(_ message: String, info: RequestLogInfo?)
+}
+```
+
+Default: `DefaultNetworkLogManager` (prints or routes to `gigLog*`).
+In tests: inject `NetworkLogManagerSpy` via the designated `init` to capture log calls.
+
+---
+
+## Pitfalls
+
+- `fetch()` **never throws** — always check `Response.status` before using `Response.data`
+- `fetchDecodable` and `fetchVoid` **do** throw — wrap in `do/catch`
+- `Response.image()` requires `@MainActor` — call inside `await MainActor.run { }` if not already on main
+- `.gigigo` standard type marks the response as failed on `{ "status": false }` even with HTTP 200 — intentional
+- `fetch()` silently returns a `.noInternet` response if reachability check fails — no exception is raised

--- a/.claude/rules/swift-style.md
+++ b/.claude/rules/swift-style.md
@@ -1,0 +1,41 @@
+# Swift Style
+
+## Access Control
+
+- `public` for library API surface
+- `internal` (default) for helpers — omit the keyword
+- `private` within types
+- Do not use `open` — the library no longer exposes open classes
+
+## Class vs Struct
+
+- `Request` and `Response` are `public class` — keep them as classes
+- Prefer structs for value types: `FileUploadData`, `KeychainOptions`, formatters
+- Formatters are stateless enums with static methods (`RequestLogFormatter`, `ResponseLogFormatter`)
+
+## MARK Comments
+
+Group methods with `// MARK: - Section Name`:
+
+```swift
+// MARK: - Public API
+// MARK: - Private Helpers
+// MARK: - Initializers
+```
+
+## Naming
+
+- Types: `UpperCamelCase`
+- Functions, variables, parameters: `lowerCamelCase`
+- Legacy public constants keep the `k` prefix (`kGIGNetworkErrorDomain`) — do not add new ones in this style
+- Protocol conformances in a separate `extension` block at the bottom of the file, or in a dedicated file
+
+## Error Handling
+
+- Throw typed errors at API boundaries: `FetchDecodableError`, `Status` (keychain)
+- Surface errors via `Response.error: NSError?` for non-throwing paths
+- Do not use `fatalError` except for programmer-error invariants that are truly unreachable
+
+## No External Dependencies
+
+Do not add packages to `Package.swift`. Vendor third-party code into `Sources/GIGLibrary/Libs/External/` and do not modify vendored files.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,86 @@
+---
+paths:
+  - "Tests/**"
+---
+
+# Testing
+
+## Framework
+
+Use **Swift Testing** — not XCTest.
+
+```swift
+import Testing
+@testable import GIGLibrary
+```
+
+## Structure
+
+```swift
+@Suite("FeatureName")
+struct FeatureTests {
+
+    @Test("Given X, when Y, then Z")
+    func someScenario() async throws {
+        // arrange
+        // act
+        // assert
+        #expect(result == expected)
+        #expect(throws: SomeError.self) { try riskyCall() }
+    }
+}
+```
+
+- Suite names: the feature or type under test
+- Test names: full Given/When/Then sentence
+- Use `@Suite(.serialized)` when tests share mutable state or network mocks
+
+## BDD Style
+
+Test observable behaviour, not implementation details:
+- ✅ "Given a successful response, the status is .success"
+- ❌ "parseJSON is called when Content-Type is JSON"
+
+Cover: happy path, error cases, edge cases (empty body, no internet, cancellation).
+
+## Dependency Injection
+
+Inject via the internal designated `init` — never reach into private state:
+
+```swift
+// Session injection
+let session = URLSession(configuration: mockConfig)
+let request = Request(method: .get, baseUrl: "...", endpoint: "/",
+                      session: session)
+
+// Reachability injection
+let request = Request(..., reachability: AlwaysReachableMock())
+
+// Log manager injection
+let spy = NetworkLogManagerSpy()
+let request = Request(..., networkLogManager: spy)
+```
+
+## Fixtures
+
+JSON fixtures live in `Tests/GIGLibraryTests/SwiftNetwork/Fakes/Fixtures/` and are bundled as an SPM resource:
+
+```swift
+// Load via FixtureLoader
+let data = try FixtureLoader.load("success_response.json")
+```
+
+## Mocks & Fakes
+
+| Type | Location | Purpose |
+|------|----------|---------|
+| `NetworkLogManagerSpy` | `Mocks/` | Captures log calls for assertion |
+| `RequestMocks` | `Mocks/` | Pre-built URLProtocol stubs |
+| `ResponseFakes` | `Fakes/` | Factory methods for Response objects |
+| `MockURLProtocol` | inline in test files | Intercepts URLSession at protocol level |
+
+## File Locations
+
+- GIGUtils tests: `Tests/GIGLibraryTests/GIGUtils/`
+- SwiftNetwork tests: `Tests/GIGLibraryTests/SwiftNetwork/`
+- Tests are discovered automatically by SPM

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md — GIGLibrary iOS
+
+**GIGLibrary** is the core iOS utility library for Gigigo projects: networking, secure storage, UI helpers, styling, logging, and Foundation/UIKit extensions. SPM only; no CocoaPods or Carthage.
+
+- **Language**: Swift 6.2 (`swiftLanguageMode(.v6)`)
+- **Minimum platform**: iOS 16.0
+- **No external dependencies**
+- **Concurrency**: `StrictConcurrency` + `ApproachableConcurrency` enabled
+
+## Repository Layout
+
+```
+gigigo-swift-lib/
+├── Package.swift
+├── AGENTS.md
+├── .swiftlint.yml
+├── Sources/GIGLibrary/
+│   ├── SwiftNetwork/      # Async HTTP client
+│   ├── KeychainStore/     # Secure Keychain wrapper
+│   ├── GIGScanner/        # QR code scanner (AVCapture)
+│   ├── GIGUtils/          # Extensions and helpers
+│   └── Libs/External/     # Vendored third-party code (do not modify)
+└── Tests/GIGLibraryTests/
+    ├── GIGUtils/
+    └── SwiftNetwork/
+```
+
+## Commands
+
+```bash
+# Tests (macOS only — do not run on Linux)
+swift test
+xcodebuild -scheme GIGLibrary \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' test
+
+# Lint
+swiftlint          # check
+swiftlint --fix    # auto-fix
+
+# Open in Xcode (no .xcodeproj)
+xed .
+```
+
+## CI
+
+File: `.github/workflows/ci.yml` — triggers on push/PR to `main`, `master`, `develop`.
+Runner: `macos-latest`, Xcode `>= 26`, iPhone 17 Pro simulator.
+
+## Branching
+
+- `main` / `master` — stable releases
+- `develop` — integration branch (most up to date)
+- `feature/<name>` / `claude/<name>` — feature branches


### PR DESCRIPTION
## Summary

Añade documentación estructurada para Claude Code siguiendo el sistema de `rules` con carga selectiva por tema.

- **`CLAUDE.md`** (raíz, ~53 líneas): visión general del proyecto, árbol de directorios de primer nivel, comandos esenciales (`swift test`, `xcodebuild`, `swiftlint`), configuración de CI y estrategia de branching.
- **`.claude/rules/architecture.md`**: árbol detallado de `Sources/` y `Tests/`, tabla de módulos y utilidades, constantes públicas de la API, guías para añadir nuevas utilidades o helpers de red.
- **`.claude/rules/swift-style.md`**: control de acceso, class vs struct, MARK comments, naming conventions, gestión de errores, política de dependencias externas.
- **`.claude/rules/concurrency.md`**: reglas de `async/await`, uso de `@MainActor`, anotaciones `Sendable`, gestión de `Task` no estructurados.
- **`.claude/rules/networking.md`** *(path-scoped)*: referencia completa de la API de `SwiftNetwork` — `Request`, `Response`, `FetchDecodableError`, `NetworkLogManaging`, formato JSON Gigigo, pitfalls. Solo carga cuando Claude trabaja en `Sources/GIGLibrary/SwiftNetwork/**` o `Tests/GIGLibraryTests/SwiftNetwork/**`.
- **`.claude/rules/keychain.md`** *(path-scoped)*: API de `KeychainStore`, builder pattern, subscript vs throwing. Solo carga en `Sources/GIGLibrary/KeychainStore/**`.
- **`.claude/rules/testing.md`** *(path-scoped)*: convenciones de Swift Testing (`@Suite`, `@Test`, `#expect`), estilo BDD, uso de fixtures, mocks e inyección de dependencias. Solo carga en `Tests/**`.

## Decisiones

- Se usó `develop` como base (más actualizado que `master`): Swift 6.2, iOS 16, API async/await completa, SwiftLint, tests con Swift Testing.
- Las rules con `paths:` frontmatter solo se cargan en contexto cuando Claude trabaja en archivos que coinciden con el patrón — reduce el ruido en tareas que no involucran esos módulos.
- El `CLAUDE.md` raíz se mantiene intencionalmente corto; el detalle vive en las rules.

## Test plan

- [ ] Verificar que `CLAUDE.md` tiene < 80 líneas
- [ ] Verificar que `.claude/rules/` contiene los 6 archivos
- [ ] Verificar que `networking.md`, `keychain.md` y `testing.md` tienen frontmatter `paths:`
- [ ] Confirmar que el diff de la PR muestra solo los 7 archivos nuevos/modificados contra `develop`