### PR TITLE
ci: bump GitHub Actions to Node.js 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:


### PR DESCRIPTION
## Qué

Actualiza las GitHub Actions del workflow de CI para que corran sobre el runtime de **Node.js 24**, eliminando el aviso de deprecación:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/checkout@v4`.

GitHub forzará Node.js 24 a partir del **2 de junio de 2026** y retirará Node.js 20 del runner el **16 de septiembre de 2026**.

## Cambios

| Action | Antes | Después | Runtime |
|--------|-------|---------|---------|
| `actions/checkout` | `@v4` | `@v6` | node20 ❌ → **node24** ✅ |
| `maxim-lobanov/setup-xcode` | `@v1` | `@v1` (sin cambios) | ya en **node24** ✅ |

- **`actions/checkout`**: `@v4` corre sobre el runtime deprecado Node.js 20. Se sube a `@v6`, la última major estable (v6.0.2), que corre sobre Node.js 24. Verificado leyendo `runs.using` en el `action.yml` de cada tag (`v4` → `node20`, `v5`/`v6` → `node24`).
- **`maxim-lobanov/setup-xcode@v1`**: el tag flotante `@v1` ya resuelve a `v1.7.0`, cuyo `action.yml` declara `using: 'node24'`. Por eso el aviso de CI **no** lo listaba. No requiere cambios.

## Qué NO cambia

La lógica del workflow se mantiene intacta: los pasos de SwiftLint (`swiftlint lint --strict`) y de tests (`xcodebuild -scheme GIGLibrary ... test`) son idénticos. Solo se modifican versiones de actions.

## Verificación

- Sintaxis YAML validada con el parser Psych de Ruby (`YAML.load_file`) → OK.
- Diff de una sola línea (`@v4` → `@v6`).
- La desaparición del aviso de deprecación se confirmará en el primer run de CI de este PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)