### PR TITLE
fix(ImageDownloader): make the success-path test deterministic in CI

### DIFF
--- a/Sources/GIGLibrary/GIGUtils/Image/ImageDownloader.swift
+++ b/Sources/GIGLibrary/GIGUtils/Image/ImageDownloader.swift
@@ -27,6 +27,15 @@ struct ImageDownloader {
     static var requestProvider: (_ url: String) -> Request = { url in
         Request(method: .get, baseUrl: url, endpoint: "", bodyParams: nil)
     }
+
+    /// Seam used only by DEBUG builds so tests can supply a `Response` directly instead of letting
+    /// the request hit `URLSession`. The real `URLSession` can stall under CI load (surfacing as
+    /// `-1001` timeouts), which made the success-path test flaky; injecting a `Response` carrying
+    /// the image bytes keeps that test deterministic while still exercising the real decode → resize
+    /// → cache. It does not exist in release builds — see `startDownload(for:)`.
+    static var fetchProvider: (_ request: Request) async -> Response = { request in
+        await request.fetch()
+    }
     #endif
 
     /// Backing store for `maxConcurrentDownloads`, always clamped to a minimum of 1.
@@ -121,7 +130,11 @@ struct ImageDownloader {
                 self.finishDownload()
                 return
             }
+            #if DEBUG
+            let response = await ImageDownloader.fetchProvider(request)
+            #else
             let response = await request.fetch()
+            #endif
             self.handleResponse(response, view: view, request: request)
         }
     }

--- a/Tests/GIGLibraryTests/GIGUtils/ImageDownloaderTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/ImageDownloaderTests.swift
@@ -76,13 +76,20 @@ struct ImageDownloaderTests {
     func successReleasesSlotAndCaches() async {
         ImageDownloader.resetForTesting()
         let urlString = "https://example.com/success.png"
-        registerImageResponse(path: "/success.png")
+        // Inject a PNG response directly instead of going through URLSession, whose stalls under CI
+        // load (NSURLError -1001) made this test flaky. The success path (decode → resize → cache)
+        // still runs for real. The Response's `url` is only nominal — the cache key is
+        // `request.baseURL` — so any valid URL works. See `ImageDownloader.fetchProvider`.
+        ImageDownloader.fetchProvider = { _ in
+            makeImageResponse(body: makePNGData(), url: URL(fileURLWithPath: "/success.png"))
+        }
 
         let view = makeImageView()
         ImageDownloader.shared.download(url: urlString, for: view, placeholder: nil)
         #expect(ImageDownloader.activeDownloads == 1)
 
-        // The slot is freed as soon as the network finishes; the image is cached after the resize.
+        // The slot is freed as soon as the (mocked) network finishes; the image is cached after the
+        // resize completes on the cooperative pool.
         let cached = await waitUntil { ImageDownloader.images[urlString] != nil }
         #expect(cached)
         #expect(ImageDownloader.activeDownloads == 0)
@@ -208,14 +215,6 @@ struct ImageDownloaderTests {
 
     // MARK: - Helpers
 
-    /// Registers a mock route returning a valid PNG for `path`, and points the downloader at a
-    /// `Request` backed by the mock `URLSession`. Use when the test needs the success path
-    /// (image decoding + resize + caching).
-    private func registerImageResponse(path: String) {
-        MockURLProtocol.respond(path: path, statusCode: 200, headers: nil, data: makePNGData())
-        ImageDownloader.requestProvider = { url in Request.testRequest(baseUrl: url, endpoint: "") }
-    }
-
     /// Points the downloader at requests that fail fast in `preChecks` (reachability off), so each
     /// download finishes immediately via the error path WITHOUT touching `URLSession` or the resize.
     /// Use for tests that only assert the slot counter / queue: the mechanics of `pump`/the counter
@@ -270,6 +269,7 @@ extension ImageDownloader {
         activeDownloads = 0
         maxConcurrentDownloads = 6  // setter clamps and pumps (a no-op while the stack is empty)
         requestProvider = { url in Request(method: .get, baseUrl: url, endpoint: "", bodyParams: nil) }
+        fetchProvider = { request in await request.fetch() }
     }
 }
 


### PR DESCRIPTION
## Problema

`successReleasesSlotAndCaches` (`Tests/GIGLibraryTests/GIGUtils/ImageDownloaderTests.swift`) era **flaky en CI**. Es el único test que ejercita la ruta de éxito completa del `ImageDownloader` (descarga vía `URLSession` interceptada por `MockURLProtocol` → decode PNG → resize en el pool cooperativo → cache en `images[url]`).

Bajo runners de CI lentos/cargados, `URLSession` se atascaba y la petición acababa en `NSURLError -1001` (timeout): la imagen nunca llegaba a `images[url]` dentro de los 30s del helper `waitUntil` y el test fallaba intermitentemente. Con el **mismo código**, al re-lanzar el job pasaba (verificado en el run de Actions 28109224997: falló y luego pasó en re-run). Localmente pasaba siempre.

Los demás tests evitan esto con `useFailFastRequests()` (reachability off → terminan por la ruta de error sin tocar `URLSession`), pero el de éxito no podía porque necesita el decode/resize/cache real.

## Solución

Se añade un seam `fetchProvider` **solo en `#if DEBUG`** (mismo patrón que el `requestProvider` existente) que permite a los tests inyectar una `Response` directamente en lugar de pasar por `URLSession`:

- El test de éxito inyecta una `Response` con **bytes PNG reales**, de modo que **sigue ejercitando decode → resize → cache y la liberación del slot de verdad**, pero sin el transporte de red no determinista.
- El seam vive tras `#if DEBUG`; la ruta de release mantiene `await request.fetch()` **sin cambios**.
- `resetForTesting()` resetea el seam al default, evitando fugas de estado entre tests.

## Verificación

- Los 12 tests de `ImageDownloaderTests` pasan; el de éxito pasa de depender de un timeout de 30s a correr en ~0.03–0.05s sin tocar `URLSession`.
- `swiftlint` limpio en los archivos modificados.
- Revisado iterativamente con un revisor de PR (varias rondas con subagente limpio) hasta no encontrar hallazgos: correcto en corrección, concurrencia/Sendable, frontera DEBUG/release, fugas de estado y cobertura real de la ruta de éxito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)