### PR TITLE
refactor(api)!: replace `open` with `public`/`public final` (C002)

### DIFF
--- a/Sources/GIGLibrary/GIGScanner/GIGScannerVC.swift
+++ b/Sources/GIGLibrary/GIGScanner/GIGScannerVC.swift
@@ -14,16 +14,16 @@ public protocol GIGScannerOutput {
 	func didSuccessfullyScan(_ scannedValue: String, type: String)
 }
 
-open class GIGScannerVC: UIViewController, @preconcurrency AVCaptureMetadataOutputObjectsDelegate {
+public class GIGScannerVC: UIViewController, @preconcurrency AVCaptureMetadataOutputObjectsDelegate {
 	
-	open var scannerOutput: GIGScannerOutput?
+	public var scannerOutput: GIGScannerOutput?
 	var captureSession: AVCaptureSession?
 	var previewLayer: AVCaptureVideoPreviewLayer?
 	var codeFrameView: UIView?
 	// swiftlint:disable:next implicitly_unwrapped_optional
 	var captureDevice: AVCaptureDevice!
 	
-	override open func viewDidLoad() {
+	override public func viewDidLoad() {
 		super.viewDidLoad()
 		self.captureDevice = AVCaptureDevice.default(for: AVMediaType.video)
 		

--- a/Sources/GIGLibrary/GIGUtils/ActionSheet/ActionSheet.swift
+++ b/Sources/GIGLibrary/GIGUtils/ActionSheet/ActionSheet.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-open class ActionSheet: AlertController {
+public final class ActionSheet: AlertController {
     
     public override init(title: String, message: String) {
         super.init(title: title, message: message, style: .actionSheet)

--- a/Sources/GIGLibrary/GIGUtils/AlertController/Alert.swift
+++ b/Sources/GIGLibrary/GIGUtils/AlertController/Alert.swift
@@ -17,7 +17,7 @@ protocol AlertInterface {
 }
 
 @MainActor
-open class Alert: NSObject {
+public final class Alert: NSObject {
     
     internal let interface: AlertInterface
 
@@ -31,19 +31,19 @@ open class Alert: NSObject {
         super.init()
     }
     
-    open func show() {
+    public func show() {
         self.interface.show()
     }
     
-    open func addDefaultButton(_ title: String, usingAction: ((String) -> Void)?) {
+    public func addDefaultButton(_ title: String, usingAction: ((String) -> Void)?) {
         self.interface.addDefaultButton(title, usingAction: usingAction)
     }
     
-    open func addCancelButton(_ title: String, usingAction: ((String) -> Void)?) {
+    public func addCancelButton(_ title: String, usingAction: ((String) -> Void)?) {
         self.interface.addCancelButton(title, usingAction: usingAction)
     }
     
-    open func addDestructiveButton(_ title: String, usingAction: ((String) -> Void)?) {
+    public func addDestructiveButton(_ title: String, usingAction: ((String) -> Void)?) {
         self.interface.addDestructiveButton(title, usingAction: usingAction)
 
     }

--- a/Sources/GIGLibrary/GIGUtils/AlertController/AlertController.swift
+++ b/Sources/GIGLibrary/GIGUtils/AlertController/AlertController.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 @MainActor
-open class AlertController: NSObject, AlertInterface {
+public class AlertController: NSObject, AlertInterface {
     
     var alert: UIAlertController
     
@@ -26,11 +26,11 @@ open class AlertController: NSObject, AlertInterface {
         self.alert = UIAlertController(title: title, message: message, preferredStyle: style)
     }
     
-    open func show() {
+    public func show() {
 		Application().presentModal(self.alert)
     }
     
-    open func addDefaultButton(_ title: String, usingAction: ((String) -> Void)?) {
+    public func addDefaultButton(_ title: String, usingAction: ((String) -> Void)?) {
         let action = UIAlertAction(title: title, style: .default) { action in
 			guard let usingAction else { return }
             usingAction(action.title ?? "")
@@ -38,7 +38,7 @@ open class AlertController: NSObject, AlertInterface {
         self.alert.addAction(action)
     }
     
-    open func addCancelButton(_ title: String, usingAction: ((String) -> Void)?) {
+    public func addCancelButton(_ title: String, usingAction: ((String) -> Void)?) {
         let action = UIAlertAction(title: title, style: .cancel) { action in
 			guard let usingAction else { return }
             usingAction(action.title ?? "")
@@ -46,7 +46,7 @@ open class AlertController: NSObject, AlertInterface {
         self.alert.addAction(action)
     }
     
-    open func addDestructiveButton(_ title: String, usingAction: ((String) -> Void)?) {
+    public func addDestructiveButton(_ title: String, usingAction: ((String) -> Void)?) {
         let action = UIAlertAction(title: title, style: .destructive) { action in
 			guard let usingAction else { return }
             usingAction(action.title ?? "")

--- a/Sources/GIGLibrary/GIGUtils/Application/Application.swift
+++ b/Sources/GIGLibrary/GIGUtils/Application/Application.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 @MainActor
-open class Application {
+public final class Application {
 	
 	public init() {
 		// no-op

--- a/Sources/GIGLibrary/GIGUtils/Log/Log.swift
+++ b/Sources/GIGLibrary/GIGUtils/Log/Log.swift
@@ -48,9 +48,9 @@ public extension LoggableModule {
 }
 
 public class LogManagerSettings {
-    open var logLevel: LogLevel
-    open var logStyle: LogStyle
-    open var moduleName: String?
+    public var logLevel: LogLevel
+    public var logStyle: LogStyle
+    public var moduleName: String?
     
     public init(moduleName: String? = nil, logLevel: LogLevel = .none, logStyle: LogStyle = .none) {
         self.moduleName = moduleName

--- a/Sources/GIGLibrary/GIGUtils/QRGenerator/QRGenerator.swift
+++ b/Sources/GIGLibrary/GIGUtils/QRGenerator/QRGenerator.swift
@@ -11,16 +11,16 @@ import UIKit
 import CoreImage.CIFilterBuiltins
 
 // swiftlint:disable:next type_name
-open class QR {
+public final class QR {
     
-	open class func generate(_ string: String) -> UIImage? {
+	public static func generate(_ string: String) -> UIImage? {
 		guard let outputImage: CGImage = self.generate(string) else { return nil }
 		
 		return UIImage(cgImage: outputImage)
 	}
 	
 	@MainActor
-	open class func generate(_ string: String, onView: UIImageView) {
+	public static func generate(_ string: String, onView: UIImageView) {
 		guard let image: CGImage = self.generate(string) else { return }
 		
         let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
@@ -42,7 +42,7 @@ open class QR {
 	
 	// MARK: - Private Helpers
 	
-	fileprivate class func generate(_ string: String) -> CGImage? {
+	fileprivate static func generate(_ string: String) -> CGImage? {
         let context = CIContext()
         let filter = CIFilter.qrCodeGenerator()
         filter.message = Data(string.utf8)

--- a/Sources/GIGLibrary/GIGUtils/SwiftJson/Json.swift
+++ b/Sources/GIGLibrary/GIGUtils/SwiftJson/Json.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 
-open class JSON: Sequence, CustomStringConvertible {
+public final class JSON: Sequence, CustomStringConvertible {
 	
 	private var json: Any
 	
-	open var description: String {
+	public var description: String {
 		if let data = try? JSONSerialization.data(withJSONObject: self.json, options: .prettyPrinted) as Data {
 			if let description = String(data: data, encoding: String.Encoding.utf8) {
 				return description
@@ -30,7 +30,7 @@ open class JSON: Sequence, CustomStringConvertible {
 		self.json = any
 	}
 	
-	open subscript(path: String) -> JSON? {
+	public subscript(path: String) -> JSON? {
 		guard var jsonDict = self.json as? [String: Any] else {
 			return nil
 		}
@@ -54,13 +54,13 @@ open class JSON: Sequence, CustomStringConvertible {
 		return JSON(from: json)
 	}
     
-    open subscript(index: Int) -> JSON? {
+    public subscript(index: Int) -> JSON? {
         guard let array = self.json as? [Any], array.count > index else { return nil }
         
         return JSON(from: array[index])
     }
 	
-	open class func dataToJson(_ data: Data) throws -> JSON {
+	public static func dataToJson(_ data: Data) throws -> JSON {
 		let jsonObject = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
 		
 		return JSON(from: jsonObject)
@@ -69,7 +69,7 @@ open class JSON: Sequence, CustomStringConvertible {
 	
 	// MARK: - Public methods
 	
-	open func toData() -> Data? {
+	public func toData() -> Data? {
 		do {
 			return try JSONSerialization.data(withJSONObject: self.json)
 		} catch let error as NSError {
@@ -78,11 +78,11 @@ open class JSON: Sequence, CustomStringConvertible {
 		}
 	}
 	
-	open func toBool() -> Bool? {
+	public func toBool() -> Bool? {
 		return self.json as? Bool
 	}
 		
-	open func toInt() -> Int? {
+	public func toInt() -> Int? {
 		if let value = self.json as? Int {
 			return value
 		}
@@ -93,11 +93,11 @@ open class JSON: Sequence, CustomStringConvertible {
 		return nil
 	}
 		
-	open func toString() -> String? {
+	public func toString() -> String? {
 		return self.json as? String
 	}
 	
-	open func toDate(_ format: String = DateISOFormat) -> Date? {
+	public func toDate(_ format: String = DateISOFormat) -> Date? {
 		guard let dateString = self.json as? String else {
 			return nil
 		}
@@ -105,11 +105,11 @@ open class JSON: Sequence, CustomStringConvertible {
 		return Date.dateFromString(dateString, format: format)
 	}
     
-    open func toDouble() -> Double? {
+    public func toDouble() -> Double? {
         return self.json as? Double
     }
     
-    open func toDictionary() -> [String: Any]? {
+    public func toDictionary() -> [String: Any]? {
         
         guard let dic = self.json as? [String: Any] else {
             return [:]
@@ -118,7 +118,7 @@ open class JSON: Sequence, CustomStringConvertible {
         return dic
     }
     
-    open func toArray() -> [Any]? {
+    public func toArray() -> [Any]? {
         guard let array = self.json as? [Any] else {
             return []
         }
@@ -128,7 +128,7 @@ open class JSON: Sequence, CustomStringConvertible {
 	
 	// MARK: - Sequence Methods
 	
-	open func makeIterator() -> AnyIterator<JSON> {
+	public func makeIterator() -> AnyIterator<JSON> {
 		var index = 0
 		
 		return AnyIterator { () -> JSON? in

--- a/Sources/GIGLibrary/GIGUtils/TextView/ExpandableTextView/ExpandableTextView.swift
+++ b/Sources/GIGLibrary/GIGUtils/TextView/ExpandableTextView/ExpandableTextView.swift
@@ -8,15 +8,15 @@
 
 import UIKit
 
-open class ExpandableTextView: UIView {
+public final class ExpandableTextView: UIView {
     
     // MARK: IBOutlet
-    @IBOutlet weak open var stackView: UIStackView!
-    @IBOutlet weak open var hyperlinkTextView: HyperlinkTextView!
+    @IBOutlet weak public var stackView: UIStackView!
+    @IBOutlet weak public var hyperlinkTextView: HyperlinkTextView!
     
     // MARK: - Public properties
     
-    open var isCollapsed: Bool = true
+    public var isCollapsed: Bool = true
     
     // MARK: - Private properties
     
@@ -32,7 +32,7 @@ open class ExpandableTextView: UIView {
     ///   - shortText: Title for the alert
     ///   - longText: Message for the alert
     /// - Returns: The `ExpandableTextView` instance
-    open class func instantiate(shortText: String, longText: String, hyperlinkDelegate: HyperlinkTextViewDelegate?) -> ExpandableTextView? {
+    public static func instantiate(shortText: String, longText: String, hyperlinkDelegate: HyperlinkTextViewDelegate?) -> ExpandableTextView? {
         let expandableTextView = self.instantiate()
         expandableTextView?.shortText = shortText
         expandableTextView?.longText = longText
@@ -41,14 +41,14 @@ open class ExpandableTextView: UIView {
         return expandableTextView
     }
     
-    open func collapse() {
+    public func collapse() {
         guard !self.isCollapsed else { return }
         self.isCollapsed = true
         guard let shortText = self.shortText else { return }
         self.hyperlinkTextView.setText(htmlText: shortText)
     }
     
-    open func expand() {
+    public func expand() {
         guard self.isCollapsed else { return }
         self.isCollapsed = false
         guard
@@ -59,7 +59,7 @@ open class ExpandableTextView: UIView {
     
     // MARK: - Private methods
     
-    private class func instantiate() -> ExpandableTextView? {
+    private static func instantiate() -> ExpandableTextView? {
         guard let expandableTextView = Bundle(for: ExpandableTextView.self).loadNibNamed("ExpandableTextView", owner: self, options: nil)?.first as? ExpandableTextView else {
             return ExpandableTextView()
         }

--- a/Sources/GIGLibrary/GIGUtils/TextView/HyperlinkTextView/HyperlinkTextView.swift
+++ b/Sources/GIGLibrary/GIGUtils/TextView/HyperlinkTextView/HyperlinkTextView.swift
@@ -12,10 +12,10 @@ public protocol HyperlinkTextViewDelegate: AnyObject {
     func didTapOnHyperlink(URL: URL)
 }
 
-open class HyperlinkTextView: UITextView {
+public final class HyperlinkTextView: UITextView {
     
     // MARK: - Public properties
-    weak open var hyperlinkDelegate: HyperlinkTextViewDelegate?
+    weak public var hyperlinkDelegate: HyperlinkTextViewDelegate?
     
     // MARK: - Private properties
     private var linkTapGestureRecognizer: UITapGestureRecognizer?
@@ -32,7 +32,7 @@ open class HyperlinkTextView: UITextView {
         self.setup()
     }
     
-    override open func awakeFromNib() {
+    override public func awakeFromNib() {
         super.awakeFromNib()
         // awakeFromNib is nonisolated but UIKit always invokes it on the main thread,
         // so we can safely assume main-actor isolation to run the @MainActor setup().
@@ -53,7 +53,7 @@ open class HyperlinkTextView: UITextView {
     
     // MARK: - Public methods
     
-    open func setText(htmlText: String) {
+    public func setText(htmlText: String) {
         let styledAttributedText = self.setupAttributedString(from: htmlText)
         self.attributedText = styledAttributedText
     }

--- a/Sources/GIGLibrary/KeychainStore/KeychainStore.swift
+++ b/Sources/GIGLibrary/KeychainStore/KeychainStore.swift
@@ -10,7 +10,7 @@ import Foundation
 import Security
 import LocalAuthentication
 
-open class KeychainStore {
+public final class KeychainStore {
 
     public var service: String {
         return self.options.service
@@ -430,7 +430,7 @@ open class KeychainStore {
 
     // MARK: Items
 
-    public class func allKeys() -> [(String, String)] {
+    public static func allKeys() -> [(String, String)] {
         var query = [String: Any]()
         query[KeychainConstants.Class] = KeychainConstants.ClassGenericPassword
         query[KeychainConstants.AttributeSynchronizable] = KeychainConstants.SynchronizableAny
@@ -465,7 +465,7 @@ open class KeychainStore {
         return allItems.compactMap(filter)
     }
 
-    public class func allItems() -> [[String: Any]] {
+    public static func allItems() -> [[String: Any]] {
         var query = [String: Any]()
         query[KeychainConstants.Class] = KeychainConstants.ClassGenericPassword
         query[KeychainConstants.MatchLimit] = KeychainConstants.MatchLimitAll
@@ -518,7 +518,7 @@ open class KeychainStore {
         return []
     }
 
-    fileprivate class func prettify(items: [[String: Any]]) -> [[String: Any]] {
+    fileprivate static func prettify(items: [[String: Any]]) -> [[String: Any]] {
         return items.map { attributes -> [String: Any] in
             var item = [String: Any]()
 
@@ -557,7 +557,7 @@ open class KeychainStore {
     }
 
     @discardableResult
-    fileprivate class func securityError(status: OSStatus) -> Error {
+    fileprivate static func securityError(status: OSStatus) -> Error {
         return Status(status: status)
     }
 


### PR DESCRIPTION
## Qué

Hallazgo de auditoría de release **C002** (ALTO, api-design). La regla del repo (`.claude/rules/swift-style.md`) prohíbe `open` ("the library no longer exposes open classes"), pero quedaban todas las declaraciones `open` repartidas en 11 archivos públicos. Este PR las baja a `public`, marcando `public final` toda clase que no necesita ser subclaseada, y convierte `class func` → `static func` en las clases ahora `final`.

### Acceso resultante

| Clase | Resultado | Motivo |
|-------|-----------|--------|
| `JSON`, `QR`, `Application`, `ExpandableTextView`, `HyperlinkTextView`, `ActionSheet`, `Alert`, `KeychainStore` | `public final` | hojas, sin subclases en el repo |
| `AlertController` | `public` (sin `final`) | la subclasea `ActionSheet` |
| `GIGScannerVC` | `public` (sin `final`) | `UIViewController`, punto de extensión razonable |
| `LogManagerSettings` | `open var` → `public var` | la clase ya era `public`; los `open var` eran inertes pero violaban la regla |

Falsos positivos respetados (no tocados): `UIApplication.shared.open(url)` y strings descriptivas en `Application.swift` / `Status.swift`.

## Por qué ahora

Pasar de `open` a `public`/`public final` es **source-breaking**: rompe subclases/overrides externos. Por eso debe hacerse en esta release y no después, y queda documentado como `BREAKING CHANGE` en el commit. `KeychainStore` ya tenía init designado `fileprivate`, así que `final` no cambia su API externa (nunca fue subclasable fuera del módulo).

## Para el revisor

- **Cambio de comportamiento de compilación para consumidores:** quien subclasee `JSON`, `QR`, `Application`, `ExpandableTextView`, `HyperlinkTextView`, `AlertController`, `ActionSheet`, `Alert`, `KeychainStore` o `GIGScannerVC` desde fuera de GIGLibrary dejará de compilar.
- `class func` → `static func` en `JSON`, `QR`, `ExpandableTextView`, `KeychainStore` (regla SwiftLint `static_over_final_class`). Call-sites verificados (sobrecargas instancia/tipo de `KeychainStore.securityError`/`allKeys`/`allItems`/`prettify` intactas).
- **Solapamiento de merge:** toca declaraciones de clase en `Log.swift`, `KeychainStore.swift` y `GIGScannerVC.swift`. C001 (KeychainStore) ya está en `develop` y el rebase fue limpio; tener en cuenta el orden de merge si hay otras tareas de la auditoría en vuelo sobre esos archivos.

## Verificación

- `xcodebuild build` (Debug **y** Release) → `BUILD SUCCEEDED`, 0 warnings (Release incluido para destapar warnings de StrictConcurrency).
- `xcodebuild test` → **120/120 tests** pasan (iPhone 17 Pro, simulador).
- `swiftlint` → **0** warnings/errores.
- `grep` final: cero modificadores `open` restantes.
- Doble revisión con subagente revisor de PR iOS (2 rondas, segunda limpia).

🤖 Generated with [Claude Code](https://claude.com/claude-code)