### PR TITLE
fix(Request): guard in-flight cancellation with a lock (C004/C007)

### DIFF
--- a/Sources/GIGLibrary/SwiftNetwork/Request+Cancellation.swift
+++ b/Sources/GIGLibrary/SwiftNetwork/Request+Cancellation.swift
@@ -1,0 +1,81 @@
+//
+//  Request+Cancellation.swift
+//  GIGLibrary
+//
+//  Cancellation machinery for `Request`. The in-flight canceller is guarded by `Request.inFlight`
+//  (an `OSAllocatedUnfairLock`), so `cancel()` is safe to call from any thread/actor concurrently
+//  with the `@concurrent` fetch body that installs and clears it on a background executor.
+//
+//  Each fetch attempt runs inside a generation scope:
+//    1. `beginCancellationScope()` opens a new generation (and cancels any still-installed prior
+//       attempt, e.g. a second `fetch()` on the same instance superseding the first).
+//    2. `installCanceller(_:generation:)` stores the canceller for that generation.
+//    3. `clearCanceller(generation:)` clears it on completion, but only if still current.
+//
+//  The generation token closes two races at the root:
+//    - a `cancel()` arriving *before* the canceller is installed is latched and fired on install
+//      (no lost cancel across the create-Task / assign-canceller window);
+//    - a stale attempt unwinding can neither clear nor be cancelled in place of a newer attempt.
+//
+
+import Foundation
+import os
+
+extension Request {
+
+    // MARK: - Public API
+
+    /// Cancels the in-flight network operation, if any. Safe to call from any thread/actor. If a
+    /// fetch has opened its cancellation scope but not yet installed its canceller, the request is
+    /// latched so the canceller fires the instant it is installed.
+    public func cancel() {
+        let cancel = self.inFlight.withLock { state -> (@Sendable () -> Void)? in
+            state.cancelRequestedGeneration = state.generation
+            let cancel = state.cancel
+            state.cancel = nil
+            return cancel
+        }
+        cancel?()
+    }
+
+    // MARK: - In-flight scope
+
+    /// Opens a fresh cancellation scope for a new fetch attempt and returns its generation token.
+    /// Cancels any canceller still installed from a previous attempt and clears the early-cancel
+    /// latch so it cannot bleed into the new attempt.
+    func beginCancellationScope() -> Int {
+        let (prior, generation) = self.inFlight.withLock { state -> ((@Sendable () -> Void)?, Int) in
+            let prior = state.cancel
+            state.generation += 1
+            state.cancel = nil
+            state.cancelRequestedGeneration = nil
+            return (prior, state.generation)
+        }
+        prior?()
+        return generation
+    }
+
+    /// Installs the canceller for the attempt identified by `generation`. Fires it immediately
+    /// instead of storing it when the attempt was already cancelled or has been superseded by a
+    /// newer attempt, so neither an early `cancel()` nor an overtaken operation can leak.
+    func installCanceller(_ cancel: @escaping @Sendable () -> Void, generation: Int) {
+        let fireNow = self.inFlight.withLock { state -> Bool in
+            guard state.generation == generation, state.cancelRequestedGeneration != generation else {
+                return true
+            }
+            state.cancel = cancel
+            return false
+        }
+        if fireNow { cancel() }
+    }
+
+    /// Clears the canceller once an attempt finishes, but only if it is still the current attempt.
+    /// A stale attempt unwinding must never wipe a newer attempt's canceller.
+    func clearCanceller(generation: Int) {
+        self.inFlight.withLock { state in
+            if state.generation == generation {
+                state.cancel = nil
+            }
+        }
+    }
+}

--- a/Sources/GIGLibrary/SwiftNetwork/Request.swift
+++ b/Sources/GIGLibrary/SwiftNetwork/Request.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import os
 
 public enum StandardType {
     case gigigo
@@ -52,8 +53,14 @@ extension URLError.Code {
     static var cannotEncodeContentData: URLError.Code { .cannotParseResponse }
 }
 
+/// `@unchecked Sendable` is sound by design under a single invariant: a `Request` is fully
+/// configured before it is fetched and its configuration is never mutated across a concurrency
+/// boundary. The only state mutated *while a fetch is in flight* is the cancellation handle, and
+/// that handle is guarded by `inFlight` (an `OSAllocatedUnfairLock`). `cancel()` may therefore be
+/// called safely from any thread/actor (e.g. `ImageDownloader` on the `MainActor`) concurrently
+/// with the `@concurrent` fetch body that runs on a background executor.
 public class Request: Selfie, @unchecked Sendable {
-	
+
     public var method: HTTPMethod
     public var baseURL: String
     public var endpoint: String
@@ -71,8 +78,19 @@ public class Request: Selfie, @unchecked Sendable {
     private var logInfo: RequestLogInfo?
     private var networkLogManager: NetworkLogManaging
 	
-	private var request: URLRequest?
-    private var cancelInFlight: (() -> Void)?
+    /// Lock-protected cancellation state for the in-flight network operation. Replaces the former
+    /// unsynchronized `cancelInFlight` closure (read/written from the background fetch executor
+    /// while `cancel()` could run from another thread — a genuine data race `@unchecked Sendable`
+    /// hid). `internal` rather than `private` only so the cancellation machinery can live in
+    /// `Request+Cancellation.swift`, which is where the generation scheme is documented.
+    struct InFlightCancellation {
+        var generation = 0
+        var cancel: (@Sendable () -> Void)?
+        var cancelRequestedGeneration: Int?
+    }
+
+    let inFlight = OSAllocatedUnfairLock(initialState: InFlightCancellation())
+
     private let reachability: ReachabilityInput
     private let sessionConfiguration: URLSessionConfiguration?
     private let session: URLSession?
@@ -215,15 +233,15 @@ public class Request: Selfie, @unchecked Sendable {
         do {
             try self.preChecks()
             let request = try self.buildRequest()
-            let session = try self.prepareSession(for: request, applyCache: true)
+            let (session, generation) = try self.prepareSession(for: request, applyCache: true)
             defer {
                 session.finishTasksAndInvalidate()
             }
 
             let operation = Task { try await session.data(for: request) }
-            self.cancelInFlight = { operation.cancel() }
+            self.installCanceller({ operation.cancel() }, generation: generation)
             defer {
-                self.cancelInFlight = nil
+                self.clearCanceller(generation: generation)
             }
 
             let (data, urlResponse) = try await withTaskCancellationHandler {
@@ -301,15 +319,15 @@ public class Request: Selfie, @unchecked Sendable {
         do {
             try self.preChecks()
             let request = try self.buildRequest()
-            let session = try self.prepareSession(for: request, applyCache: false)
+            let (session, generation) = try self.prepareSession(for: request, applyCache: false)
             defer {
                 session.finishTasksAndInvalidate()
             }
 
             let operation = Task { try await session.download(for: request) }
-            self.cancelInFlight = { operation.cancel() }
+            self.installCanceller({ operation.cancel() }, generation: generation)
             defer {
-                self.cancelInFlight = nil
+                self.clearCanceller(generation: generation)
             }
 
             let (location, urlResponse) = try await withTaskCancellationHandler {
@@ -344,15 +362,15 @@ public class Request: Selfie, @unchecked Sendable {
         do {
             try self.preChecks()
             let (request, bodyData) = try self.buildUploadRequest(files: files, params: params)
-            let session = try self.prepareSession(for: request, bodyForLog: bodyData, applyCache: false)
+            let (session, generation) = try self.prepareSession(for: request, bodyForLog: bodyData, applyCache: false)
             defer {
                 session.finishTasksAndInvalidate()
             }
 
             let operation = Task { try await session.upload(for: request, from: bodyData) }
-            self.cancelInFlight = { operation.cancel() }
+            self.installCanceller({ operation.cancel() }, generation: generation)
             defer {
-                self.cancelInFlight = nil
+                self.clearCanceller(generation: generation)
             }
 
             let (data, urlResponse) = try await withTaskCancellationHandler {
@@ -379,12 +397,6 @@ public class Request: Selfie, @unchecked Sendable {
         }
     }
 
-	public func cancel() {
-        self.cancelInFlight?()
-        self.cancelInFlight = nil
-	}
-	
-	
 	// MARK: - Private Helpers
     
     private func controlCache(config: URLSessionConfiguration) {
@@ -463,21 +475,27 @@ public class Request: Selfie, @unchecked Sendable {
         for request: URLRequest,
         bodyForLog: Data? = nil,
         applyCache: Bool
-    ) throws -> URLSession {
+    ) throws -> (session: URLSession, generation: Int) {
         var requestForLog = request
         if let bodyForLog {
             requestForLog.httpBody = bodyForLog
         }
-        self.request = requestForLog
-        self.logRequest()
-        self.cancel()
+        self.logRequest(requestForLog)
+        // Opens this attempt's cancellation scope (and cancels any prior in-flight attempt on this
+        // instance) at the same point the legacy synchronous `cancel()` ran, before the session is
+        // configured — so a superseding `fetch()` tears the previous one down without a timing shift.
+        let generation = self.beginCancellationScope()
 
         let session = self.configuredSession(applyCache: applyCache)
         if Task.isCancelled {
+            // The caller installs `defer { session.finishTasksAndInvalidate() }` only on the
+            // returned value, so invalidate here before throwing or this session (and the delegate
+            // it retains) would leak until ARC reclaims it.
+            session.finishTasksAndInvalidate()
             self.logRequestError(message: "Request cancelled before execution.")
             throw RequestBuildError.cancelledBeforeExecution
         }
-        return session
+        return (session, generation)
     }
 
     private func buildUploadRequest(
@@ -594,15 +612,15 @@ public class Request: Selfie, @unchecked Sendable {
         return url?.string
     }
 	
-	fileprivate func logRequest() {
+	fileprivate func logRequest(_ request: URLRequest) {
         guard self.verbose else { return }
-        
+
         if self.logInfo == nil {
             LogManager.shared.logLevel = .debug
             LogManager.shared.appName = "GIGLibrary"
         }
-        
-        let log = RequestLogFormatter.buildRequestLog(request: self.request)
+
+        let log = RequestLogFormatter.buildRequestLog(request: request)
         self.networkLogManager.log(log, info: self.logInfo)
 	}
     


### PR DESCRIPTION
## Qué

`Request` es `public class … @unchecked Sendable` pero mutaba estado compartido **sin sincronización**: `cancelInFlight: (() -> Void)?` y `request: URLRequest?` se escribían desde el cuerpo `@concurrent` de `fetch()/upload()/fetch(downloadTo:)` (executor de fondo) mientras `cancel()` podía invocarse desde otro hilo/actor (p. ej. `ImageDownloader` en `@MainActor`). Es una **data race real** sobre un closure ref-contado, con riesgo de use-after-free / over-release o cancelación perdida; el `@unchecked Sendable` ocultaba el diagnóstico. Hallazgo de auditoría de release **C004/C007** (ALTO, concurrency).

## Cómo

- Sustituye `cancelInFlight`/`request` por un `InFlightCancellation` protegido con **`OSAllocatedUnfairLock`** (iOS 16+). Un **token de generación** acota cada intento de fetch: una finalización tardía no puede limpiar (ni un `cancel()` alcanzar) un intento más nuevo, y un `cancel()` que llega **antes** de instalar el canceller queda *latcheado* y se dispara al instalar — cerrando de raíz la ventana de carrera crear-`Task` / asignar-canceller.
- La maquinaria de cancelación vive en el nuevo **`Request+Cancellation.swift`** (para no superar el límite `file_length` de SwiftLint, que el CI corre con `--strict`). El `cancel()` **público mantiene su contrato** (sigue cancelando trabajo en vuelo), y se conserva `withTaskCancellationHandler`, así que la cancelación estructurada por `Task` también sigue funcionando.
- `logRequest(_:)` recibe el `URLRequest` por parámetro en vez de almacenarlo en `self`, eliminando la otra propiedad mutable sin proteger.
- Se invalida la `URLSession` en el camino de throw `cancelledBeforeExecution` (antes se filtraba hasta que ARC la reclamaba — defecto preexistente en el mismo método).
- Se documenta la invariante que justifica `@unchecked Sendable`.

### Por qué un lock y no cancelación 100% estructurada
Hay tests que exigen que `request.cancel()` cancele operaciones **en vuelo** (`fetchReturnsCancelledWhenRequestIsCancelled`, upload/download equivalentes, y `fetchCancelsPreviousRequestWhenCalledAgain`). Neutralizar `cancel()` habría roto ese contrato público y obligado a reescribir el delicado `ImageDownloader`. El lock elimina la data race, justifica el `@unchecked Sendable` y mantiene el comportamiento.

## Verificación

- `swiftlint lint --strict` — limpio.
- `xcodebuild … test` (iPhone 17 Pro) — **120 tests / 6 suites**, 0 fallos.
- `xcodebuild … test -enableThreadSanitizer YES` — sin data races atribuibles a estos cambios.
- Compila warning-free bajo Swift 6.2 `StrictConcurrency` + `ApproachableConcurrency`.

## Notas para el revisor

- Tres rondas de revisión con subagentes limpios e independientes; convergió a *sin hallazgos*.
- Durante la verificación con TSan se observó (de forma *flaky*) una **data race preexistente e independiente en `LogManager`** (`Log.swift`): los setters `logLevel`/`appName`/`logStyle` escriben `defaultSettings` sin pasar por el `queue` que sí usa el resto de la clase. **No forma parte de este PR** (no toca `LogManager`); queda anotada para un fix aparte.