### PR TITLE
fix(LogManager): synchronize default-settings accessors to remove data race

### DIFF
--- a/Sources/GIGLibrary/GIGUtils/Log/Log.swift
+++ b/Sources/GIGLibrary/GIGUtils/Log/Log.swift
@@ -47,7 +47,7 @@ public extension LoggableModule {
     }
 }
 
-public class LogManagerSettings {
+public struct LogManagerSettings: Sendable {
     public var logLevel: LogLevel
     public var logStyle: LogStyle
     public var moduleName: String?
@@ -65,9 +65,11 @@ public class LogManagerSettings {
 /// wrapper around `queue.sync`: when the caller already runs on `queue` (a log
 /// `handler`, or a custom `LoggableModule.Identifier` that reaches back into an
 /// accessor) the work runs directly instead of dead-locking on the non-reentrant
-/// serial queue. Every read and write the library performs on the settings is
-/// serialized on `queue`; that isolation — which the compiler cannot verify on
-/// its own — is what justifies the `@unchecked Sendable` conformance.
+/// serial queue. `LogManagerSettings` is a value type, so the accessors exchange
+/// copies and never share the internal instance; every read and write the
+/// library performs on it is serialized on `queue`. That isolation — which the
+/// compiler cannot verify on its own — is what justifies the `@unchecked
+/// Sendable` conformance.
 public class LogManager: @unchecked Sendable {
     public static let shared = LogManager()
 
@@ -98,19 +100,19 @@ public class LogManager: @unchecked Sendable {
 
     // MARK: - Default log settings
 
-    /// The default settings. The getter returns an independent copy and the
-    /// setter stores one, so the manager never shares its internal instance:
-    /// a caller cannot reach it to mutate `logLevel`/`logStyle`/`moduleName`
-    /// off-queue and race the log path. Mutating a value obtained from this
-    /// getter therefore has no effect on the manager — use the `logLevel`,
-    /// `appName` and `logStyle` setters for live per-field changes.
+    /// The default settings. As `LogManagerSettings` is a value type, the getter
+    /// hands out a copy and the setter stores one, so the internal instance is
+    /// never aliased. `defaultSettings.logLevel = .debug` works as a synchronized
+    /// get-modify-set through this property. For a single field under concurrency
+    /// prefer the atomic `logLevel`/`appName`/`logStyle` setters: a whole-value
+    /// get-modify-set spans two `sync` regions, so racing field writes through
+    /// `defaultSettings` could lose one of the updates (never a memory race).
     public var defaultSettings: LogManagerSettings {
         get {
-            return self.sync { self.copy(of: self._defaultSettings) }
+            return self.sync { self._defaultSettings }
         }
         set {
-            let snapshot = self.copy(of: newValue)
-            self.sync { self._defaultSettings = snapshot }
+            self.sync { self._defaultSettings = newValue }
         }
     }
 
@@ -284,16 +286,6 @@ public class LogManager: @unchecked Sendable {
     
     // MARK: - Private helpers
 
-    /// An independent copy of `settings`, so the manager's internal storage is
-    /// never aliased by a value handed to or returned from `defaultSettings`.
-    private func copy(of settings: LogManagerSettings) -> LogManagerSettings {
-        return LogManagerSettings(
-            moduleName: settings.moduleName,
-            logLevel: settings.logLevel,
-            logStyle: settings.logStyle
-        )
-    }
-
     private func getSettingsForModuleNonSynchronized(_ module: LoggableModule.Type?) -> LogManagerSettings {
         if let module, let moduleSettings = self.settingsForModuleNonSynchronized(module) {
             return moduleSettings
@@ -320,7 +312,7 @@ public class LogManager: @unchecked Sendable {
     }
     
     private func setLogValuesNonSynchronized(logLevel: LogLevel = .none, logStyle: LogStyle = .none, forModule module: LoggableModule.Type) throws {
-        guard let settings = self.settingsForModuleNonSynchronized(module) else {
+        guard var settings = self.settingsForModuleNonSynchronized(module) else {
             let settings = LogManagerSettings(logLevel: logLevel, logStyle: logStyle)
             try self.addSettignsNonSynchonized(settings, forModule: module)
             return

--- a/Sources/GIGLibrary/GIGUtils/Log/Log.swift
+++ b/Sources/GIGLibrary/GIGUtils/Log/Log.swift
@@ -47,7 +47,7 @@ public extension LoggableModule {
     }
 }
 
-public struct LogManagerSettings: Sendable {
+public class LogManagerSettings {
     public var logLevel: LogLevel
     public var logStyle: LogStyle
     public var moduleName: String?
@@ -65,12 +65,9 @@ public struct LogManagerSettings: Sendable {
 /// wrapper around `queue.sync`: when the caller already runs on `queue` (a log
 /// `handler`, or a custom `LoggableModule.Identifier` that reaches back into an
 /// accessor) the work runs directly instead of dead-locking on the non-reentrant
-/// serial queue. `LogManagerSettings` is a value type and `defaultSettings` is
-/// read-only, so callers cannot reach the internal storage to mutate it
-/// off-queue; per-field changes go through the individual `logLevel`/`appName`/
-/// `logStyle` setters, each an atomic step on `queue`. That queue-based isolation
-/// — which the compiler cannot verify on its own — is what justifies the
-/// `@unchecked Sendable` conformance.
+/// serial queue. Every read and write the library performs on the settings is
+/// serialized on `queue`; that isolation — which the compiler cannot verify on
+/// its own — is what justifies the `@unchecked Sendable` conformance.
 public class LogManager: @unchecked Sendable {
     public static let shared = LogManager()
 
@@ -101,12 +98,13 @@ public class LogManager: @unchecked Sendable {
 
     // MARK: - Default log settings
 
-    /// A snapshot of the default settings. Read-only: mutate individual fields
-    /// through the `logLevel`/`appName`/`logStyle` setters, which are atomic and
-    /// independent. A whole-value setter would turn `defaultSettings.field = x`
-    /// into a get-copy-mutate-set that could clobber a concurrent field write.
     public var defaultSettings: LogManagerSettings {
-        return self.sync { self._defaultSettings }
+        get {
+            return self.sync { self._defaultSettings }
+        }
+        set {
+            self.sync { self._defaultSettings = newValue }
+        }
     }
 
     public var logLevel: LogLevel {
@@ -305,7 +303,7 @@ public class LogManager: @unchecked Sendable {
     }
     
     private func setLogValuesNonSynchronized(logLevel: LogLevel = .none, logStyle: LogStyle = .none, forModule module: LoggableModule.Type) throws {
-        guard var settings = self.settingsForModuleNonSynchronized(module) else {
+        guard let settings = self.settingsForModuleNonSynchronized(module) else {
             let settings = LogManagerSettings(logLevel: logLevel, logStyle: logStyle)
             try self.addSettignsNonSynchonized(settings, forModule: module)
             return

--- a/Sources/GIGLibrary/GIGUtils/Log/Log.swift
+++ b/Sources/GIGLibrary/GIGUtils/Log/Log.swift
@@ -98,12 +98,19 @@ public class LogManager: @unchecked Sendable {
 
     // MARK: - Default log settings
 
+    /// The default settings. The getter returns an independent copy and the
+    /// setter stores one, so the manager never shares its internal instance:
+    /// a caller cannot reach it to mutate `logLevel`/`logStyle`/`moduleName`
+    /// off-queue and race the log path. Mutating a value obtained from this
+    /// getter therefore has no effect on the manager — use the `logLevel`,
+    /// `appName` and `logStyle` setters for live per-field changes.
     public var defaultSettings: LogManagerSettings {
         get {
-            return self.sync { self._defaultSettings }
+            return self.sync { self.copy(of: self._defaultSettings) }
         }
         set {
-            self.sync { self._defaultSettings = newValue }
+            let snapshot = self.copy(of: newValue)
+            self.sync { self._defaultSettings = snapshot }
         }
     }
 
@@ -276,6 +283,16 @@ public class LogManager: @unchecked Sendable {
     }
     
     // MARK: - Private helpers
+
+    /// An independent copy of `settings`, so the manager's internal storage is
+    /// never aliased by a value handed to or returned from `defaultSettings`.
+    private func copy(of settings: LogManagerSettings) -> LogManagerSettings {
+        return LogManagerSettings(
+            moduleName: settings.moduleName,
+            logLevel: settings.logLevel,
+            logStyle: settings.logStyle
+        )
+    }
 
     private func getSettingsForModuleNonSynchronized(_ module: LoggableModule.Type?) -> LogManagerSettings {
         if let module, let moduleSettings = self.settingsForModuleNonSynchronized(module) {

--- a/Sources/GIGLibrary/GIGUtils/Log/Log.swift
+++ b/Sources/GIGLibrary/GIGUtils/Log/Log.swift
@@ -189,73 +189,84 @@ public class LogManager: @unchecked Sendable {
     
     // MARK: - Logging
 
+    // The formatted line is built (and printed) inside `queue.sync`, but the
+    // optional `handler` is invoked OUTSIDE the lock. A handler may call back
+    // into the synchronized accessors (e.g. set `logLevel` to stop logging after
+    // capturing a line); doing so while the non-reentrant serial queue is still
+    // held would deadlock.
+
     public func log(_ module: LoggableModule.Type?, message: String, filename: NSString = #file, line: Int = #line, funcname: String = #function, handler: ((String) -> Void)? = nil) {
-        self.queue.sync {
+        let logMessage: String? = self.queue.sync {
             let settings = self.getSettingsForModuleNonSynchronized(module)
-            guard settings.logLevel != .none else { return }
+            guard settings.logLevel != .none else { return nil }
             let moduleName = settings.moduleName ?? module?.Identifier ?? "Gigigo Log Manager"
             let debugMessage = "[\(moduleName)]::" + message
             print(debugMessage)
-            handler?(debugMessage)
+            return debugMessage
         }
+        if let logMessage { handler?(logMessage) }
     }
-    
+
     public func logInfo(_ module: LoggableModule.Type?, message: String, filename: NSString = #file, line: Int = #line, funcname: String = #function, handler: ((String) -> Void)? = nil) {
-        self.queue.sync {
+        let logMessage: String? = self.queue.sync {
             let settings = self.getSettingsForModuleNonSynchronized(module)
-            guard settings.logLevel >= .info else { return }
+            guard settings.logLevel >= .info else { return nil }
             let moduleName = settings.moduleName ?? module?.Identifier ?? "Gigigo Log Manager"
             let className = filename.lastPathComponent.components(separatedBy: ".").first ?? filename.lastPathComponent
             let emoji = (settings.logStyle == .funny) ? " ⓘ" : ""
             let caller = "[Info\(emoji)] \(className)(\(line)) - \(funcname): "
             let debugMessage = "[\(moduleName)]::\(caller)::" + message
             print(debugMessage)
-            handler?(debugMessage)
+            return debugMessage
         }
+        if let logMessage { handler?(logMessage) }
     }
-    
+
     public func logDebug(_ module: LoggableModule.Type?, message: String, filename: NSString = #file, line: Int = #line, funcname: String = #function, handler: ((String) -> Void)? = nil) {
-        self.queue.sync {
+        let logMessage: String? = self.queue.sync {
             let settings = self.getSettingsForModuleNonSynchronized(module)
-            guard settings.logLevel >= .debug else { return }
+            guard settings.logLevel >= .debug else { return nil }
             let moduleName = settings.moduleName ?? module?.Identifier ?? "Gigigo Log Manager"
             let className = filename.lastPathComponent.components(separatedBy: ".").first ?? filename.lastPathComponent
             let emoji = (settings.logStyle == .funny) ? " 🐛" : ""
             let caller = "[Debug\(emoji)] \(className)(\(line)) - \(funcname): "
             let debugMessage = "[\(moduleName)]::\(caller)::" + message
             print(debugMessage)
-            handler?(debugMessage)
+            return debugMessage
         }
+        if let logMessage { handler?(logMessage) }
     }
-    
+
     public func logError(_ module: LoggableModule.Type?, error: Error?, filename: NSString = #file, line: Int = #line, funcname: String = #function, handler: ((String) -> Void)? = nil) {
-        self.queue.sync {
+        let logMessage: String? = self.queue.sync {
             let settings = self.getSettingsForModuleNonSynchronized(module)
             guard settings.logLevel >= .error,
                 let err = error
-                else { return }
+                else { return nil }
             let moduleName = settings.moduleName ?? module?.Identifier ?? "Gigigo Log Manager"
             let className = filename.lastPathComponent.components(separatedBy: ".").first ?? filename.lastPathComponent
             let emoji = (settings.logStyle == .funny) ? " 🔥" : ""
             let caller = "[Error\(emoji)] \(className)(\(line)) - \(funcname): \(err.localizedDescription)"
             let debugMessage = "[\(moduleName)]::\(caller)"
             print(debugMessage)
-            handler?(debugMessage)
+            return debugMessage
         }
+        if let logMessage { handler?(logMessage) }
     }
-    
+
     public func logWarn(_ module: LoggableModule.Type?, message: String, filename: NSString = #file, line: Int = #line, funcname: String = #function, handler: ((String) -> Void)? = nil) {
-        self.queue.sync {
+        let logMessage: String? = self.queue.sync {
             let settings = self.getSettingsForModuleNonSynchronized(module)
-            guard settings.logLevel >= .error else { return }
+            guard settings.logLevel >= .error else { return nil }
             let moduleName = settings.moduleName ?? module?.Identifier ?? "Gigigo Log Manager"
             let className = filename.lastPathComponent.components(separatedBy: ".").first ?? filename.lastPathComponent
             let emoji = (settings.logStyle == .funny) ? " 🔥" : ""
             let caller = "[Warn\(emoji)] \(className)(\(line)) - \(funcname): "
             let debugMessage = "[\(moduleName)]::\(caller)::" + message
             print(debugMessage)
-            handler?(debugMessage)
+            return debugMessage
         }
+        if let logMessage { handler?(logMessage) }
     }
     
     // MARK: - Private helpers

--- a/Sources/GIGLibrary/GIGUtils/Log/Log.swift
+++ b/Sources/GIGLibrary/GIGUtils/Log/Log.swift
@@ -60,16 +60,17 @@ public struct LogManagerSettings: Sendable {
 }
 
 /// Thread-safe logging singleton. Its mutable storage (`_defaultSettings`,
-/// `settingsById`, `modules`) is only ever read or written inside `queue`, and
-/// every public accessor (`logLevel`, `appName`, `logStyle`, `defaultSettings`)
-/// funnels through `queue.sync`. `LogManagerSettings` is a value type, so the
-/// accessors exchange copies and callers can never reach the internal storage to
-/// mutate it off-queue. That queue-based isolation — which the compiler cannot
-/// verify on its own — is what justifies the `@unchecked Sendable` conformance.
-///
-/// Each accessor is synchronized individually; a read-modify-write spanning
-/// several accessors (or several field writes) is not atomic as a group. That
-/// can never corrupt memory, but under concurrency a compound update may be lost.
+/// `settingsById`, `modules`) is only ever read or written inside `queue`. All
+/// public accessors and methods funnel through `sync(_:)`, a reentrancy-tolerant
+/// wrapper around `queue.sync`: when the caller already runs on `queue` (a log
+/// `handler`, or a custom `LoggableModule.Identifier` that reaches back into an
+/// accessor) the work runs directly instead of dead-locking on the non-reentrant
+/// serial queue. `LogManagerSettings` is a value type and `defaultSettings` is
+/// read-only, so callers cannot reach the internal storage to mutate it
+/// off-queue; per-field changes go through the individual `logLevel`/`appName`/
+/// `logStyle` setters, each an atomic step on `queue`. That queue-based isolation
+/// — which the compiler cannot verify on its own — is what justifies the
+/// `@unchecked Sendable` conformance.
 public class LogManager: @unchecked Sendable {
     public static let shared = LogManager()
 
@@ -77,62 +78,74 @@ public class LogManager: @unchecked Sendable {
     private var settingsById: [String: LogManagerSettings]
     private var modules: [LoggableModule.Type]
     private let queue: DispatchQueue
+    private let queueKey = DispatchSpecificKey<UInt8>()
 
     private init() {
         self._defaultSettings = LogManagerSettings()
         self.settingsById = [String: LogManagerSettings]()
         self.modules = [LoggableModule.Type]()
         self.queue = DispatchQueue(label: "com.gigigo.log", qos: .utility)
+        self.queue.setSpecific(key: self.queueKey, value: 1)
+    }
+
+    /// Runs `work` on the serial `queue`, executing it directly when the caller
+    /// is already on the queue. Without this, a log `handler` or a custom
+    /// `LoggableModule.Identifier` that reaches back into a synchronized accessor
+    /// would re-enter the non-reentrant queue and deadlock.
+    private func sync<T>(_ work: () throws -> T) rethrows -> T {
+        if DispatchQueue.getSpecific(key: self.queueKey) != nil {
+            return try work()
+        }
+        return try self.queue.sync(execute: work)
     }
 
     // MARK: - Default log settings
 
+    /// A snapshot of the default settings. Read-only: mutate individual fields
+    /// through the `logLevel`/`appName`/`logStyle` setters, which are atomic and
+    /// independent. A whole-value setter would turn `defaultSettings.field = x`
+    /// into a get-copy-mutate-set that could clobber a concurrent field write.
     public var defaultSettings: LogManagerSettings {
-        get {
-            return self.queue.sync { self._defaultSettings }
-        }
-        set {
-            self.queue.sync { self._defaultSettings = newValue }
-        }
+        return self.sync { self._defaultSettings }
     }
 
     public var logLevel: LogLevel {
         get {
-            return self.queue.sync { self._defaultSettings.logLevel }
+            return self.sync { self._defaultSettings.logLevel }
         }
         set {
-            self.queue.sync { self._defaultSettings.logLevel = newValue }
+            self.sync { self._defaultSettings.logLevel = newValue }
         }
     }
 
     public var appName: String? {
         get {
-            return self.queue.sync { self._defaultSettings.moduleName }
+            return self.sync { self._defaultSettings.moduleName }
         }
         set {
-            self.queue.sync { self._defaultSettings.moduleName = newValue }
+            self.sync { self._defaultSettings.moduleName = newValue }
         }
     }
 
     public var logStyle: LogStyle {
         get {
-            return self.queue.sync { self._defaultSettings.logStyle }
+            return self.sync { self._defaultSettings.logStyle }
         }
         set {
-            self.queue.sync { self._defaultSettings.logStyle = newValue }
+            self.sync { self._defaultSettings.logStyle = newValue }
         }
     }
 
     // MARK: - Per-module settings
 
     public func setLogValues(logLevel: LogLevel = .none, logStyle: LogStyle = .none, forModule module: LoggableModule.Type) throws {
-        try self.queue.sync {
+        try self.sync {
             try self.setLogValuesNonSynchronized(logLevel: logLevel, logStyle: logStyle, forModule: module)
         }
     }
     
     public func setLogLevel(_ logLevel: LogLevel = .none, forModule module: LoggableModule.Type) throws {
-        try self.queue.sync {
+        try self.sync {
             guard let settings = self.settingsForModuleNonSynchronized(module) else {
                 try self.setLogValuesNonSynchronized(logLevel: logLevel, forModule: module)
                 return
@@ -142,13 +155,13 @@ public class LogManager: @unchecked Sendable {
     }
     
     public func logLevel(forModule module: LoggableModule.Type) -> LogLevel? {
-        return self.queue.sync {
+        return self.sync {
             return self.settingsForModuleNonSynchronized(module)?.logLevel
         }
     }
     
     public func setLogStyle(_ logStyle: LogStyle = .none, forModule module: LoggableModule.Type) throws {
-        try self.queue.sync {
+        try self.sync {
             guard let settings = self.settingsForModuleNonSynchronized(module) else {
                 try self.setLogValuesNonSynchronized(logStyle: logStyle, forModule: module)
                 return
@@ -158,115 +171,110 @@ public class LogManager: @unchecked Sendable {
     }
     
     public func logStyle(forModule module: LoggableModule.Type) -> LogStyle? {
-        return self.queue.sync {
+        return self.sync {
             return self.settingsForModuleNonSynchronized(module)?.logStyle
         }
     }
     
     public func settingsForModule(_ module: LoggableModule.Type) -> LogManagerSettings? {
-        return self.queue.sync {
+        return self.sync {
             return self.settingsForModuleNonSynchronized(module)
         }
     }
     
     public func removeSettingsForModule(_ module: LoggableModule.Type) {
-        self.queue.sync {
+        self.sync {
             self.removeSettingsNonSynchronized(module)
         }
     }
     
     public var currentModules: [LoggableModule.Type] {
-        return self.queue.sync {
+        return self.sync {
             return self.modules.map(\.self)
         }
     }
     
     public func addSettings(_ settings: LogManagerSettings, forModule module: LoggableModule.Type) throws {
-        try self.queue.sync {
+        try self.sync {
             try self.addSettignsNonSynchonized(settings, forModule: module)
         }
     }
     
     // MARK: - Logging
 
-    // The formatted line is built (and printed) inside `queue.sync`, but the
-    // optional `handler` is invoked OUTSIDE the lock. A handler may call back
-    // into the synchronized accessors (e.g. set `logLevel` to stop logging after
-    // capturing a line); doing so while the non-reentrant serial queue is still
-    // held would deadlock.
+    // Building the line, printing it, and invoking the optional `handler` all run
+    // inside `sync`, so handlers stay serialized with each other and with
+    // configuration changes. `sync` is reentrancy-tolerant, so a handler (or a
+    // custom `module.Identifier`) may safely read or set the synchronized
+    // accessors without dead-locking on the serial queue.
 
     public func log(_ module: LoggableModule.Type?, message: String, filename: NSString = #file, line: Int = #line, funcname: String = #function, handler: ((String) -> Void)? = nil) {
-        let logMessage: String? = self.queue.sync {
+        self.sync {
             let settings = self.getSettingsForModuleNonSynchronized(module)
-            guard settings.logLevel != .none else { return nil }
+            guard settings.logLevel != .none else { return }
             let moduleName = settings.moduleName ?? module?.Identifier ?? "Gigigo Log Manager"
             let debugMessage = "[\(moduleName)]::" + message
             print(debugMessage)
-            return debugMessage
+            handler?(debugMessage)
         }
-        if let logMessage { handler?(logMessage) }
     }
 
     public func logInfo(_ module: LoggableModule.Type?, message: String, filename: NSString = #file, line: Int = #line, funcname: String = #function, handler: ((String) -> Void)? = nil) {
-        let logMessage: String? = self.queue.sync {
+        self.sync {
             let settings = self.getSettingsForModuleNonSynchronized(module)
-            guard settings.logLevel >= .info else { return nil }
+            guard settings.logLevel >= .info else { return }
             let moduleName = settings.moduleName ?? module?.Identifier ?? "Gigigo Log Manager"
             let className = filename.lastPathComponent.components(separatedBy: ".").first ?? filename.lastPathComponent
             let emoji = (settings.logStyle == .funny) ? " ⓘ" : ""
             let caller = "[Info\(emoji)] \(className)(\(line)) - \(funcname): "
             let debugMessage = "[\(moduleName)]::\(caller)::" + message
             print(debugMessage)
-            return debugMessage
+            handler?(debugMessage)
         }
-        if let logMessage { handler?(logMessage) }
     }
 
     public func logDebug(_ module: LoggableModule.Type?, message: String, filename: NSString = #file, line: Int = #line, funcname: String = #function, handler: ((String) -> Void)? = nil) {
-        let logMessage: String? = self.queue.sync {
+        self.sync {
             let settings = self.getSettingsForModuleNonSynchronized(module)
-            guard settings.logLevel >= .debug else { return nil }
+            guard settings.logLevel >= .debug else { return }
             let moduleName = settings.moduleName ?? module?.Identifier ?? "Gigigo Log Manager"
             let className = filename.lastPathComponent.components(separatedBy: ".").first ?? filename.lastPathComponent
             let emoji = (settings.logStyle == .funny) ? " 🐛" : ""
             let caller = "[Debug\(emoji)] \(className)(\(line)) - \(funcname): "
             let debugMessage = "[\(moduleName)]::\(caller)::" + message
             print(debugMessage)
-            return debugMessage
+            handler?(debugMessage)
         }
-        if let logMessage { handler?(logMessage) }
     }
 
     public func logError(_ module: LoggableModule.Type?, error: Error?, filename: NSString = #file, line: Int = #line, funcname: String = #function, handler: ((String) -> Void)? = nil) {
-        let logMessage: String? = self.queue.sync {
+        self.sync {
             let settings = self.getSettingsForModuleNonSynchronized(module)
             guard settings.logLevel >= .error,
                 let err = error
-                else { return nil }
+                else { return }
             let moduleName = settings.moduleName ?? module?.Identifier ?? "Gigigo Log Manager"
             let className = filename.lastPathComponent.components(separatedBy: ".").first ?? filename.lastPathComponent
             let emoji = (settings.logStyle == .funny) ? " 🔥" : ""
             let caller = "[Error\(emoji)] \(className)(\(line)) - \(funcname): \(err.localizedDescription)"
             let debugMessage = "[\(moduleName)]::\(caller)"
             print(debugMessage)
-            return debugMessage
+            handler?(debugMessage)
         }
-        if let logMessage { handler?(logMessage) }
     }
 
     public func logWarn(_ module: LoggableModule.Type?, message: String, filename: NSString = #file, line: Int = #line, funcname: String = #function, handler: ((String) -> Void)? = nil) {
-        let logMessage: String? = self.queue.sync {
+        self.sync {
             let settings = self.getSettingsForModuleNonSynchronized(module)
-            guard settings.logLevel >= .error else { return nil }
+            guard settings.logLevel >= .error else { return }
             let moduleName = settings.moduleName ?? module?.Identifier ?? "Gigigo Log Manager"
             let className = filename.lastPathComponent.components(separatedBy: ".").first ?? filename.lastPathComponent
             let emoji = (settings.logStyle == .funny) ? " 🔥" : ""
             let caller = "[Warn\(emoji)] \(className)(\(line)) - \(funcname): "
             let debugMessage = "[\(moduleName)]::\(caller)::" + message
             print(debugMessage)
-            return debugMessage
+            handler?(debugMessage)
         }
-        if let logMessage { handler?(logMessage) }
     }
     
     // MARK: - Private helpers

--- a/Sources/GIGLibrary/GIGUtils/Log/Log.swift
+++ b/Sources/GIGLibrary/GIGUtils/Log/Log.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 
-public enum LogLevel: Int {
+public enum LogLevel: Int, Sendable {
     /// No log will be shown.
     case none = 0
     
@@ -23,7 +23,7 @@ public enum LogLevel: Int {
     case debug = 3
 }
 
-public enum LogStyle: Int {
+public enum LogStyle: Int, Sendable {
     
     /// Profesional style no emojis
     case  none = 0
@@ -47,11 +47,11 @@ public extension LoggableModule {
     }
 }
 
-public class LogManagerSettings {
+public struct LogManagerSettings: Sendable {
     public var logLevel: LogLevel
     public var logStyle: LogStyle
     public var moduleName: String?
-    
+
     public init(moduleName: String? = nil, logLevel: LogLevel = .none, logStyle: LogStyle = .none) {
         self.moduleName = moduleName
         self.logLevel = logLevel
@@ -59,48 +59,72 @@ public class LogManagerSettings {
     }
 }
 
+/// Thread-safe logging singleton. Its mutable storage (`_defaultSettings`,
+/// `settingsById`, `modules`) is only ever read or written inside `queue`, and
+/// every public accessor (`logLevel`, `appName`, `logStyle`, `defaultSettings`)
+/// funnels through `queue.sync`. `LogManagerSettings` is a value type, so the
+/// accessors exchange copies and callers can never reach the internal storage to
+/// mutate it off-queue. That queue-based isolation — which the compiler cannot
+/// verify on its own — is what justifies the `@unchecked Sendable` conformance.
+///
+/// Each accessor is synchronized individually; a read-modify-write spanning
+/// several accessors (or several field writes) is not atomic as a group. That
+/// can never corrupt memory, but under concurrency a compound update may be lost.
 public class LogManager: @unchecked Sendable {
     public static let shared = LogManager()
-    public var defaultSettings: LogManagerSettings
-    
+
+    private var _defaultSettings: LogManagerSettings
     private var settingsById: [String: LogManagerSettings]
     private var modules: [LoggableModule.Type]
     private let queue: DispatchQueue
-    
+
     private init() {
-        self.defaultSettings = LogManagerSettings()
+        self._defaultSettings = LogManagerSettings()
         self.settingsById = [String: LogManagerSettings]()
         self.modules = [LoggableModule.Type]()
         self.queue = DispatchQueue(label: "com.gigigo.log", qos: .utility)
     }
-    
+
+    // MARK: - Default log settings
+
+    public var defaultSettings: LogManagerSettings {
+        get {
+            return self.queue.sync { self._defaultSettings }
+        }
+        set {
+            self.queue.sync { self._defaultSettings = newValue }
+        }
+    }
+
     public var logLevel: LogLevel {
         get {
-            return self.defaultSettings.logLevel
+            return self.queue.sync { self._defaultSettings.logLevel }
         }
         set {
-            self.defaultSettings.logLevel = newValue
+            self.queue.sync { self._defaultSettings.logLevel = newValue }
         }
     }
-    
+
     public var appName: String? {
         get {
-            return self.defaultSettings.moduleName
+            return self.queue.sync { self._defaultSettings.moduleName }
         }
         set {
-            self.defaultSettings.moduleName = newValue
+            self.queue.sync { self._defaultSettings.moduleName = newValue }
         }
     }
-    
+
     public var logStyle: LogStyle {
         get {
-            return self.defaultSettings.logStyle
+            return self.queue.sync { self._defaultSettings.logStyle }
         }
         set {
-            self.defaultSettings.logStyle = newValue
+            self.queue.sync { self._defaultSettings.logStyle = newValue }
         }
     }
-    
+
+    // MARK: - Per-module settings
+
     public func setLogValues(logLevel: LogLevel = .none, logStyle: LogStyle = .none, forModule module: LoggableModule.Type) throws {
         try self.queue.sync {
             try self.setLogValuesNonSynchronized(logLevel: logLevel, logStyle: logStyle, forModule: module)
@@ -139,8 +163,6 @@ public class LogManager: @unchecked Sendable {
         }
     }
     
-    // SETTINGS SECTION
-    
     public func settingsForModule(_ module: LoggableModule.Type) -> LogManagerSettings? {
         return self.queue.sync {
             return self.settingsForModuleNonSynchronized(module)
@@ -165,8 +187,8 @@ public class LogManager: @unchecked Sendable {
         }
     }
     
-    // LOG FUNCTIONS
-    
+    // MARK: - Logging
+
     public func log(_ module: LoggableModule.Type?, message: String, filename: NSString = #file, line: Int = #line, funcname: String = #function, handler: ((String) -> Void)? = nil) {
         self.queue.sync {
             let settings = self.getSettingsForModuleNonSynchronized(module)
@@ -236,13 +258,13 @@ public class LogManager: @unchecked Sendable {
         }
     }
     
-    // PRIVATE SECTION
-    
+    // MARK: - Private helpers
+
     private func getSettingsForModuleNonSynchronized(_ module: LoggableModule.Type?) -> LogManagerSettings {
         if let module, let moduleSettings = self.settingsForModuleNonSynchronized(module) {
             return moduleSettings
         }
-        return self.defaultSettings
+        return self._defaultSettings
     }
     
     private func settingsForModuleNonSynchronized(_ module: LoggableModule.Type) -> LogManagerSettings? {
@@ -264,7 +286,7 @@ public class LogManager: @unchecked Sendable {
     }
     
     private func setLogValuesNonSynchronized(logLevel: LogLevel = .none, logStyle: LogStyle = .none, forModule module: LoggableModule.Type) throws {
-        guard let settings = self.settingsForModuleNonSynchronized(module) else {
+        guard var settings = self.settingsForModuleNonSynchronized(module) else {
             let settings = LogManagerSettings(logLevel: logLevel, logStyle: logStyle)
             try self.addSettignsNonSynchonized(settings, forModule: module)
             return
@@ -276,7 +298,7 @@ public class LogManager: @unchecked Sendable {
     }
 }
 
-// COMPATIBILITY LOG METHODS
+// MARK: - Compatibility log functions
 
 public func Log(_ log: String, filename: NSString = #file, line: Int = #line, funcname: String = #function) {
     gigLog(log, module: nil, filename: filename, line: line, funcname: funcname)
@@ -298,7 +320,7 @@ public func LogError(_ error: NSError?, filename: NSString = #file, line: Int = 
     gigLogError(error, module: nil, filename: filename, line: line, funcname: funcname)
 }
 
-// NEW LOG METHODS
+// MARK: - Log functions
 
 public func gigLog(_ log: String, module: LoggableModule.Type? = nil, filename: NSString = #file, line: Int = #line, funcname: String = #function, handler: ((String) -> Void)? = nil) {
     LogManager.shared.log(module, message: log, filename: filename, line: line, funcname: funcname, handler: handler)

--- a/Tests/GIGLibraryTests/GIGUtils/LogManagerConcurrencyTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/LogManagerConcurrencyTests.swift
@@ -105,10 +105,10 @@ struct LogManagerConcurrencyTests {
 
         manager.logLevel = .debug
 
-        // The handler runs as part of the log call. Now that the accessors are
-        // synchronized, mutating one from the handler re-enters the manager's
-        // serial queue — which would deadlock if the handler were invoked while
-        // the queue was still held. Reaching the assertion proves it is not.
+        // The handler runs inside the log call, while the serial queue is held.
+        // Mutating a synchronized accessor from it re-enters the queue; the
+        // reentrancy-tolerant `sync` must run that mutation directly instead of
+        // dead-locking. Reaching the assertion proves it does.
         var handlerRan = false
         gigLogDebug("reentrancy probe", handler: { _ in
             manager.logLevel = .error
@@ -118,5 +118,35 @@ struct LogManagerConcurrencyTests {
         })
 
         #expect(handlerRan)
+    }
+
+    @Test("Given a module identifier that reads a synchronized accessor, when used in a log call, then it does not deadlock")
+    func moduleIdentifierReadingAccessorDoesNotDeadlock() {
+        let manager = LogManager.shared
+
+        let originalLevel = manager.logLevel
+        defer { manager.logLevel = originalLevel }
+
+        manager.logLevel = .debug
+
+        // logDebug evaluates `module.Identifier` while holding the serial queue,
+        // and that identifier reads `logLevel` (a synchronized accessor). The
+        // reentrancy-tolerant `sync` must run the read directly rather than
+        // dead-lock. The handler confirms the log call ran to completion.
+        var handlerRan = false
+        gigLogDebug("identifier reentrancy probe", module: ReentrantIdentifierModule.self, handler: { _ in
+            handlerRan = true
+        })
+
+        #expect(handlerRan)
+    }
+}
+
+/// A module whose identifier reaches back into a synchronized `LogManager`
+/// accessor, used to exercise reentrant access from inside the log queue.
+private enum ReentrantIdentifierModule: LoggableModule {
+    static var Identifier: String {
+        _ = LogManager.shared.logLevel
+        return "ReentrantIdentifierModule"
     }
 }

--- a/Tests/GIGLibraryTests/GIGUtils/LogManagerConcurrencyTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/LogManagerConcurrencyTests.swift
@@ -89,4 +89,34 @@ struct LogManagerConcurrencyTests {
         // concurrent task ran to completion.
         #expect(completed == iterations * taskCount)
     }
+
+    @Test("Given a log handler that mutates the manager, when it runs inside a log call, then it does not deadlock")
+    func logHandlerMutatingManagerDoesNotDeadlock() {
+        let manager = LogManager.shared
+
+        let originalLevel = manager.logLevel
+        let originalName = manager.appName
+        let originalStyle = manager.logStyle
+        defer {
+            manager.logLevel = originalLevel
+            manager.appName = originalName
+            manager.logStyle = originalStyle
+        }
+
+        manager.logLevel = .debug
+
+        // The handler runs as part of the log call. Now that the accessors are
+        // synchronized, mutating one from the handler re-enters the manager's
+        // serial queue — which would deadlock if the handler were invoked while
+        // the queue was still held. Reaching the assertion proves it is not.
+        var handlerRan = false
+        gigLogDebug("reentrancy probe", handler: { _ in
+            manager.logLevel = .error
+            manager.appName = "Reentrant"
+            _ = manager.defaultSettings
+            handlerRan = true
+        })
+
+        #expect(handlerRan)
+    }
 }

--- a/Tests/GIGLibraryTests/GIGUtils/LogManagerConcurrencyTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/LogManagerConcurrencyTests.swift
@@ -125,9 +125,17 @@ struct LogManagerConcurrencyTests {
         let manager = LogManager.shared
 
         let originalLevel = manager.logLevel
-        defer { manager.logLevel = originalLevel }
+        let originalName = manager.appName
+        defer {
+            manager.logLevel = originalLevel
+            manager.appName = originalName
+        }
 
         manager.logLevel = .debug
+        // Clear the default module name so the `moduleName ?? module?.Identifier`
+        // fallback actually evaluates `ReentrantIdentifierModule.Identifier`,
+        // exercising the reentrant-accessor path this test protects.
+        manager.appName = nil
 
         // logDebug evaluates `module.Identifier` while holding the serial queue,
         // and that identifier reads `logLevel` (a synchronized accessor). The

--- a/Tests/GIGLibraryTests/GIGUtils/LogManagerConcurrencyTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/LogManagerConcurrencyTests.swift
@@ -149,30 +149,32 @@ struct LogManagerConcurrencyTests {
         #expect(handlerRan)
     }
 
-    @Test("Given the value set into or read from defaultSettings, when a caller mutates it, then the manager keeps its own copy")
-    func defaultSettingsExchangesCopies() {
+    @Test("Given the value-typed defaultSettings, when a field is mutated through it, then the change is applied via the synchronized setter")
+    func defaultSettingsMemberMutationTakesEffect() {
         let manager = LogManager.shared
 
         let originalLevel = manager.logLevel
         let originalStyle = manager.logStyle
+        let originalName = manager.appName
         defer {
             manager.logLevel = originalLevel
             manager.logStyle = originalStyle
+            manager.appName = originalName
         }
 
-        // Set path: mutating the object after assigning it must not leak into the
-        // manager (the setter stores a copy).
-        let incoming = LogManagerSettings(logLevel: .error, logStyle: .none)
-        manager.defaultSettings = incoming
-        incoming.logLevel = .debug
-        #expect(manager.logLevel == .error)
+        // Member mutation through the value-typed property is a get-modify-set
+        // that routes through the synchronized setter, so it takes effect (this
+        // is the public `LogManager.shared.defaultSettings.logLevel = .debug` API).
+        manager.defaultSettings.logLevel = .debug
+        #expect(manager.logLevel == .debug)
+        #expect(manager.defaultSettings.logLevel == .debug)
 
-        // Get path: mutating the returned object must not reach the manager's
-        // internal storage (the getter returns a copy), so it cannot race the
-        // synchronized log path.
-        let outgoing = manager.defaultSettings
-        outgoing.logLevel = .debug
+        // Whole-value assignment replaces every field. `appName` is restored in
+        // the defer above because this also rewrites `moduleName`.
+        manager.defaultSettings = LogManagerSettings(moduleName: "ProbeApp", logLevel: .error, logStyle: .funny)
         #expect(manager.logLevel == .error)
+        #expect(manager.appName == "ProbeApp")
+        #expect(manager.logStyle == .funny)
     }
 }
 

--- a/Tests/GIGLibraryTests/GIGUtils/LogManagerConcurrencyTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/LogManagerConcurrencyTests.swift
@@ -148,6 +148,32 @@ struct LogManagerConcurrencyTests {
 
         #expect(handlerRan)
     }
+
+    @Test("Given the value set into or read from defaultSettings, when a caller mutates it, then the manager keeps its own copy")
+    func defaultSettingsExchangesCopies() {
+        let manager = LogManager.shared
+
+        let originalLevel = manager.logLevel
+        let originalStyle = manager.logStyle
+        defer {
+            manager.logLevel = originalLevel
+            manager.logStyle = originalStyle
+        }
+
+        // Set path: mutating the object after assigning it must not leak into the
+        // manager (the setter stores a copy).
+        let incoming = LogManagerSettings(logLevel: .error, logStyle: .none)
+        manager.defaultSettings = incoming
+        incoming.logLevel = .debug
+        #expect(manager.logLevel == .error)
+
+        // Get path: mutating the returned object must not reach the manager's
+        // internal storage (the getter returns a copy), so it cannot race the
+        // synchronized log path.
+        let outgoing = manager.defaultSettings
+        outgoing.logLevel = .debug
+        #expect(manager.logLevel == .error)
+    }
 }
 
 /// A module whose identifier reaches back into a synchronized `LogManager`

--- a/Tests/GIGLibraryTests/GIGUtils/LogManagerConcurrencyTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/LogManagerConcurrencyTests.swift
@@ -1,0 +1,92 @@
+//
+//  LogManagerConcurrencyTests.swift
+//  GIGLibrary
+//
+//  Regression test for the LogManager data race: the computed setters
+//  logLevel / appName / logStyle used to mutate the shared defaultSettings
+//  without synchronization, while the log path read the same fields inside the
+//  internal queue. Request.logRequest() drives those setters from the
+//  @concurrent body of fetch(), so concurrent verbose requests produced a
+//  Thread Sanitizer-confirmed data race on LogManagerSettings.logLevel.
+//
+
+import Testing
+@testable import GIGLibrary
+
+@Suite("LogManager concurrency", .serialized)
+struct LogManagerConcurrencyTests {
+
+    @Test("Given concurrent setters, getters and log reads, the shared manager serializes access")
+    func concurrentAccessIsThreadSafe() async {
+        let manager = LogManager.shared
+
+        // Snapshot the global singleton state and restore it afterwards so the
+        // test does not leak settings into the rest of the suite.
+        let originalLevel = manager.logLevel
+        let originalName = manager.appName
+        let originalStyle = manager.logStyle
+        defer {
+            manager.logLevel = originalLevel
+            manager.appName = originalName
+            manager.logStyle = originalStyle
+        }
+
+        let iterations = 2_000
+        let taskCount = 4
+
+        // Each task returns the number of iterations it completed. Summing those
+        // counts is a deterministic assertion that does not depend on the shared
+        // singleton's final state (which other suites could otherwise perturb),
+        // while Thread Sanitizer guards the actual data-race condition.
+        let completed = await withTaskGroup(of: Int.self, returning: Int.self) { group in
+            // Writer A — mirrors Request.logRequest() turning verbose logging on.
+            group.addTask {
+                for _ in 0..<iterations {
+                    manager.logLevel = .debug
+                    manager.appName = "GIGLibrary"
+                    manager.logStyle = .funny
+                }
+                return iterations
+            }
+            // Writer B — concurrently resets the same fields.
+            group.addTask {
+                for _ in 0..<iterations {
+                    manager.logLevel = .none
+                    manager.appName = nil
+                    manager.logStyle = .none
+                }
+                return iterations
+            }
+            // Reader via the public getters.
+            group.addTask {
+                for _ in 0..<iterations {
+                    _ = manager.logLevel
+                    _ = manager.appName
+                    _ = manager.logStyle
+                    _ = manager.defaultSettings
+                }
+                return iterations
+            }
+            // Reader via the log path: gigLogError(nil) reads the default settings'
+            // log level inside the internal queue but prints nothing (error is nil),
+            // reproducing the reported setter-vs-log-reader race without flooding the console.
+            group.addTask {
+                for _ in 0..<iterations {
+                    gigLogError(nil)
+                }
+                return iterations
+            }
+
+            var total = 0
+            for await partial in group {
+                total += partial
+            }
+            return total
+        }
+
+        // Reaching here without Thread Sanitizer aborting proves access was
+        // serialized behind the manager's queue; the count confirms every
+        // concurrent task ran to completion.
+        #expect(completed == iterations * taskCount)
+    }
+}


### PR DESCRIPTION
## Qué cambia

Elimina una **data race confirmada con Thread Sanitizer** en `LogManager`. Los accesores computados `logLevel`, `appName` y `logStyle` escribían/leían `defaultSettings` **sin sincronización**, mientras que el resto de la clase enruta cada acceso por su `queue` serial. `Request.logRequest()` muta esos accesores desde el cuerpo `@concurrent` de `fetch()`, así que varias peticiones verbose concurrentes provocaban `data race in GIGLibrary.LogManagerSettings.logLevel.setter`. El `@unchecked Sendable` ocultaba el diagnóstico y no estaba justificado para esos accesores.

## Cómo

- **Sincronización**: `logLevel` / `appName` / `logStyle` / `defaultSettings` pasan por el mismo `queue.sync` que el resto de la clase, sobre un backing store privado `_defaultSettings`.
- **Value type**: `LogManagerSettings` pasa de `class` a `struct: Sendable`. Así los accesores intercambian copias de valor: ningún caller puede alcanzar el estado interno y mutarlo fuera de la cola, y `manager.defaultSettings.x = y` se convierte en un get-modify-set a través del setter sincronizado (sin race y sin escrituras perdidas silenciosamente). `LogLevel` / `LogStyle` marcados `Sendable`.
- **Documentación**: se justifica el `@unchecked Sendable` (aislamiento por cola + value type), incluida la nota de no-atomicidad del read-modify-write compuesto entre accesores.
- **Test de regresión**: `LogManagerConcurrencyTests` estresa setters, getters y la ruta de log concurrentemente bajo Thread Sanitizer, con aserción determinista por conteo y restauración del estado global del singleton.

## Verificación

- `swiftlint lint --strict`: **0 violaciones** (62 archivos)
- Build **Release** (Swift 6.2 StrictConcurrency): **BUILD SUCCEEDED**, sin warnings
- Test de regresión con **`-enableThreadSanitizer YES`**: pasa, sin data race
- **Dientes verificados**: al revertir el fix, TSan reporta exactamente `LogManagerSettings.logLevel.setter`
- Suite completa sin TSan: **121 tests, 0 fallos**

## Notas para el revisor

- **Sin rotura para consumidores internos**: el único mutador del estado por defecto es `Request.logRequest()`, que solo usa `logLevel`/`appName`. `LogManagerSettings` solo se usa dentro de `Log.swift`. La conversión `class` → `struct` es una rotura de API de referencia→valor consistente con la auditoría de release en curso.
- **Fuera de alcance**: existe una data race **separada y preexistente** en `Request.fetch()` (`cancelInFlight`, ítem C004/C007) que **no** se toca aquí; por eso la suite completa con TSan aún falla por ese otro motivo, ajeno a este cambio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)