### PR TITLE
fix(GIGScanner): avoid crash when no capture device is available (C009)

### DIFF
--- a/Sources/GIGLibrary/GIGScanner/GIGScannerVC.swift
+++ b/Sources/GIGLibrary/GIGScanner/GIGScannerVC.swift
@@ -20,13 +20,15 @@ public class GIGScannerVC: UIViewController, @preconcurrency AVCaptureMetadataOu
 	var captureSession: AVCaptureSession?
 	var previewLayer: AVCaptureVideoPreviewLayer?
 	var codeFrameView: UIView?
-	// swiftlint:disable:next implicitly_unwrapped_optional
-	var captureDevice: AVCaptureDevice!
+	var captureDevice: AVCaptureDevice?
 	
 	override public func viewDidLoad() {
 		super.viewDidLoad()
-		self.captureDevice = AVCaptureDevice.default(for: AVMediaType.video)
-		
+		guard let captureDevice = AVCaptureDevice.default(for: AVMediaType.video) else {
+			LogWarn("No video capture device available")
+			return
+		}
+
 		do {
 			let input = try AVCaptureDeviceInput(device: captureDevice)
 			self.captureSession = AVCaptureSession()
@@ -50,7 +52,8 @@ public class GIGScannerVC: UIViewController, @preconcurrency AVCaptureMetadataOu
 			]
 			
 			self.addPreviewLayer()
-			
+			self.captureDevice = captureDevice
+
 		} catch {
 			LogWarn("Error initialize camera")
 			return
@@ -68,28 +71,29 @@ public class GIGScannerVC: UIViewController, @preconcurrency AVCaptureMetadataOu
 	}
 	
 	public func enableTorch(_ enable: Bool) {
-		
-		try? self.captureDevice.lockForConfiguration()
-		
-		if self.captureDevice.hasTorch {
-			
-			if enable {
-				self.captureDevice.torchMode = .on
-			} else {
-				self.captureDevice.torchMode = .off
+		guard let captureDevice = self.captureDevice else { return }
+
+		do {
+			try captureDevice.lockForConfiguration()
+			defer { captureDevice.unlockForConfiguration() }
+			if captureDevice.hasTorch {
+				captureDevice.torchMode = enable ? .on : .off
 			}
+		} catch let error as NSError {
+			LogError(error)
 		}
-		self.captureDevice.unlockForConfiguration()
 	}
 	
 	public func focusCamera(_ focusPoint: CGPoint) {
-		
+		guard let captureDevice = self.captureDevice else { return }
+
 		do {
-			try self.captureDevice.lockForConfiguration()
-			self.captureDevice.focusPointOfInterest = focusPoint
-			self.captureDevice.focusMode = AVCaptureDevice.FocusMode.continuousAutoFocus
-			self.captureDevice.exposurePointOfInterest = focusPoint
-			self.captureDevice.exposureMode = AVCaptureDevice.ExposureMode.continuousAutoExposure
+			try captureDevice.lockForConfiguration()
+			defer { captureDevice.unlockForConfiguration() }
+			captureDevice.focusPointOfInterest = focusPoint
+			captureDevice.focusMode = AVCaptureDevice.FocusMode.continuousAutoFocus
+			captureDevice.exposurePointOfInterest = focusPoint
+			captureDevice.exposureMode = AVCaptureDevice.ExposureMode.continuousAutoExposure
 		} catch let error as NSError {
 			LogError(error)
 		}


### PR DESCRIPTION
## Qué

Corrige un crash determinista en `GIGScannerVC` cuando no hay dispositivo de captura disponible (hallazgo de auditoría de release **C009**, severidad ALTA).

`captureDevice` era un implicitly-unwrapped optional (`AVCaptureDevice!`) asignado desde `AVCaptureDevice.default(for: .video)`, que devuelve `nil` en el **Simulador**, en dispositivos **sin cámara** o cuando la cámara **no está disponible / en uso**. Ese IUO nil se pasaba inmediatamente a `AVCaptureDeviceInput(device:)` (parámetro **no-opcional**), provocando un trap **antes** de entrar al `do/catch`. Además `enableTorch()` y `focusCamera()` forzaban el unwrap, por lo que invocarlos sin device inicializado era un crash garantizado.

## Por qué

- Crash determinista en Simulador → rompe UI tests y previews.
- Alcanzable en producción (dispositivos sin cámara, cámara ocupada, permisos).

## Cambios

- `captureDevice` pasa a ser un optional real `AVCaptureDevice?` (se elimina el `// swiftlint:disable:next implicitly_unwrapped_optional`).
- `viewDidLoad`: `guard let` sobre `AVCaptureDevice.default(for:)` con `LogWarn` y `return` antes de crear el `AVCaptureDeviceInput`. `self.captureDevice` se asigna **solo cuando toda la configuración de la sesión ha tenido éxito**, manteniendo la coherencia con `captureSession`.
- `enableTorch` / `focusCamera`: `guard let` del optional + `do/catch` con `defer { unlockForConfiguration() }`, de modo que el device solo se desbloquea si el lock tuvo éxito.

### Mejoras de comportamiento (intencionadas)

- **Lock leak corregido en `focusCamera`**: antes hacía `lockForConfiguration()` y **nunca** desbloqueaba; ahora el `defer` garantiza el `unlock`.
- **`enableTorch` más correcto**: antes, con `try?`, mutaba `torchMode` y desbloqueaba aunque el lock fallara (unlock sin lock previo); ahora, si el lock falla, es no-op + log con `LogError`.
- En entornos sin cámara, el scanner ahora **degrada con log en vez de crashear**.

## Verificación

Sobre iPhone 17 Pro simulator:
- `xcodebuild build` → **BUILD SUCCEEDED** (sin warnings de StrictConcurrency).
- `xcodebuild test` → **TEST SUCCEEDED**, 124 tests / 7 suites.
- `swiftlint` → 0 violaciones.

Revisado iterativamente con un revisor de PR de iOS hasta no encontrar hallazgos accionables (cubierto correctness, crash, concurrencia Swift 6.2, pairing lock/unlock y estilo del repo).

## Notas para el revisor

- **API pública sin cambios**: firmas de `enableTorch`/`focusCamera` intactas; solo mejora el comportamiento interno. `enableTorch`/`focusCamera` ahora son no-op silencioso si el device no está inicializado (antes crasheaban).
- **Coordinación con C002** (`open` → `public`): ya resuelta — esta rama parte de `develop` con C002 mergeado; el diff no toca modificadores de acceso.
- **Fuera de alcance** (hallazgos propios): gating de la sesión por `isCameraAvailable`/permisos, y la ausencia de tests para `GIGScanner` (AVCapture es difícil de testear sin hardware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)