### PR TITLE
fix(SwiftNetwork): harden Request/Response (S1: C024, C041, C051, C060, C061, C062, C065)

### DIFF
--- a/.claude/rules/networking.md
+++ b/.claude/rules/networking.md
@@ -99,7 +99,7 @@ FileUploadData(data: Data, mimeType: String, filename: String, name: String)
 
 Helper methods:
 - `json() throws -> JSON`
-- `image() throws -> UIImage` — **requires `@MainActor`**
+- `image(scale:) throws -> UIImage` — `nonisolated`; decode runs wherever called (callers run it off-main for network-controlled GIFs)
 
 Internal factory methods: `noInternet()`, `invalidURL()`, `cancelled()`, `cannotEncodeContentData()`
 
@@ -156,8 +156,8 @@ In tests: inject `NetworkLogManagerSpy` via the designated `init` to capture log
 
 - `fetch()` **never throws** — always check `Response.status` before using `Response.data`
 - `fetchDecodable` and `fetchVoid` **do** throw — wrap in `do/catch`
-- `Response.image()` requires `@MainActor` — call inside `await MainActor.run { }` if not already on main
-- `Response.image()` decodes `.gif` URLs as animated images (via `UIImage.gif(data:)`); other URLs decode as a single `UIImage`
+- `Response.image(scale:)` is `nonisolated` and takes the screen scale explicitly — decode GIFs off the main actor (read `UIScreen.main.scale` on main, then call from a background task) so a large/multi-frame network GIF can't block the UI
+- `Response.image(scale:)` decodes `.gif` URLs as animated images (via `UIImage.gif(data:)`); other URLs decode as a single `UIImage` at `scale`
 - `.gigigo` standard type marks the response as failed on `{ "status": false }` even with HTTP 200 — intentional
 - `fetch()` silently returns a `.noInternet` response if reachability check fails — no exception is raised
 - Only HTTP `200..<300` is `.success`; `300`+ map to an error status

--- a/.claude/rules/networking.md
+++ b/.claude/rules/networking.md
@@ -163,4 +163,4 @@ In tests: inject `NetworkLogManagerSpy` via the designated `init` to capture log
 - Only HTTP `200..<300` is `.success`; `300`+ map to an error status
 - `baseURL` must be an **absolute URL with a scheme** — a missing/invalid scheme yields an `.invalidURL` response
 - `endpoint` is **path-only**, joined to `baseURL` with exactly one `/` (no `//`, no missing slash). A `?query`/`#fragment` in `endpoint` is percent-encoded into the path; pass query items via `urlParams` or include them in `baseURL`
-- `urlParams` values are encoded by type (`String`/`Int`/`Double`/`Bool`→`true`/`false`/`NSNumber`); an array value expands to one item per element under the same name; `NSNull` yields a valueless item
+- `urlParams` values are encoded by type (`String`/`Int`/`Double`/`Bool`→`true`/`false`/`NSNumber`); an array value expands to one item per element under the same name; `NSNull` and non-finite `Double` (`NaN`/`±Inf`) yield a valueless item

--- a/.claude/rules/networking.md
+++ b/.claude/rules/networking.md
@@ -157,5 +157,10 @@ In tests: inject `NetworkLogManagerSpy` via the designated `init` to capture log
 - `fetch()` **never throws** — always check `Response.status` before using `Response.data`
 - `fetchDecodable` and `fetchVoid` **do** throw — wrap in `do/catch`
 - `Response.image()` requires `@MainActor` — call inside `await MainActor.run { }` if not already on main
+- `Response.image()` decodes `.gif` URLs as animated images (via `UIImage.gif(data:)`); other URLs decode as a single `UIImage`
 - `.gigigo` standard type marks the response as failed on `{ "status": false }` even with HTTP 200 — intentional
 - `fetch()` silently returns a `.noInternet` response if reachability check fails — no exception is raised
+- Only HTTP `200..<300` is `.success`; `300`+ map to an error status
+- `baseURL` must be an **absolute URL with a scheme** — a missing/invalid scheme yields an `.invalidURL` response
+- `endpoint` is **path-only**, joined to `baseURL` with exactly one `/` (no `//`, no missing slash). A `?query`/`#fragment` in `endpoint` is percent-encoded into the path; pass query items via `urlParams` or include them in `baseURL`
+- `urlParams` values are encoded by type (`String`/`Int`/`Double`/`Bool`→`true`/`false`/`NSNumber`); an array value expands to one item per element under the same name; `NSNull` yields a valueless item

--- a/Sources/GIGLibrary/GIGUtils/Image/ImageDownloader.swift
+++ b/Sources/GIGLibrary/GIGUtils/Image/ImageDownloader.swift
@@ -158,22 +158,27 @@ struct ImageDownloader {
     private func handleResponse(_ response: Response, view: UIImageView, request: Request) {
         switch response.status {
         case .success:
-            guard let image = try? response.image() else {
-                LogWarn("While downloading the image, the body was empty or the image type was not recognized.")
-                self.clearQueueEntry(for: view, ifCurrent: request)
-                self.finishDownload()
-                return
-            }
-            let width = view.width() * UIScreen.main.scale
-            let height = view.height() * UIScreen.main.scale
-            let targetSize = CGSize(width: width, height: height)
-            // The network download finished: release the slot now so the next one can start.
-            // Resizing is CPU work; it must not keep a download slot occupied, and a low-priority
-            // resize must never gate the concurrency counter.
+            // Read the scale and target size on the main actor (UIKit), then release the download
+            // slot and move BOTH the decode and the resize off the main actor. Decoding a
+            // network-controlled `.gif` (potentially many/large frames) on the main actor would
+            // block the UI thread; like the resize, it is CPU work that must not gate the
+            // concurrency counter or hold a download slot.
+            let scale = UIScreen.main.scale
+            let targetSize = CGSize(width: view.width() * scale, height: view.height() * scale)
             self.finishDownload()
             Task.detached(priority: .utility) {
+                guard let image = try? response.image(scale: scale) else {
+                    await MainActor.run {
+                        LogWarn("While downloading the image, the body was empty or the image type was not recognized.")
+                        self.clearQueueEntry(for: view, ifCurrent: request)
+                    }
+                    return
+                }
                 var finalImage = image
-                if let resized = image.imageProportionally(with: targetSize) {
+                // Never resize an animated image: `imageProportionally` redraws into a single
+                // graphics context, which would flatten a multi-frame GIF to one static frame and
+                // silently undo the GIF decode. Publish animated images (`images != nil`) as-is.
+                if image.images == nil, let resized = image.imageProportionally(with: targetSize) {
                     finalImage = resized
                 }
                 await MainActor.run {

--- a/Sources/GIGLibrary/GIGUtils/Image/UIImage+Extension.swift
+++ b/Sources/GIGLibrary/GIGUtils/Image/UIImage+Extension.swift
@@ -169,25 +169,28 @@ extension UIImage {
         let count = CGImageSourceGetCount(source)
         var images = [CGImage]()
         var delays = [Int]()
-        // Fill arrays
+        // Fill arrays. Keep `images` and `delays` aligned: a frame that fails to decode is skipped
+        // entirely instead of appending a delay without an image. Otherwise a partially corrupt GIF
+        // desyncs the arrays and the frame loop below traps on `images[i]` out of range — a path now
+        // reachable from untrusted network data via `Response.image()`.
         for i in 0..<count {
             // Add image
-            if let image = CGImageSourceCreateImageAtIndex(source, i, nil) {
-                images.append(image)
-            }
+            guard let image = CGImageSourceCreateImageAtIndex(source, i, nil) else { continue }
+            images.append(image)
             // At it's delay in cs
             let delaySeconds = UIImage.delayForImageAtIndex(Int(i),
                                                             source: source)
             delays.append(Int(delaySeconds * 1000.0)) // Seconds to ms
         }
+        guard !images.isEmpty else { return nil }
         // Calculate full duration
         let duration: Int = {
             var sum = 0
-            
+
             for val: Int in delays {
                 sum += val
             }
-            
+
             return sum
         }()
         // Get frames
@@ -195,10 +198,10 @@ extension UIImage {
         var frames = [UIImage]()
         var frame: UIImage
         var frameCount: Int
-        for i in 0..<count {
-            frame = UIImage(cgImage: images[Int(i)])
-            frameCount = Int(delays[Int(i)] / gcd)
-            
+        for i in 0..<images.count {
+            frame = UIImage(cgImage: images[i])
+            frameCount = Int(delays[i] / gcd)
+
             for _ in 0..<frameCount {
                 frames.append(frame)
             }

--- a/Sources/GIGLibrary/SwiftNetwork/Request+URLBuilding.swift
+++ b/Sources/GIGLibrary/SwiftNetwork/Request+URLBuilding.swift
@@ -96,6 +96,11 @@ extension Request {
             if CFGetTypeID(number) == CFBooleanGetTypeID() {
                 return number.boolValue ? "true" : "false"
             }
+            // A non-finite Double (NaN/±Inf) would render as "nan"/"inf" via stringValue and ship
+            // silent garbage to the backend; treat it as non-encodable (valueless item) instead.
+            if !number.doubleValue.isFinite {
+                return nil
+            }
             return number.stringValue
         default:
             return String(describing: value)

--- a/Sources/GIGLibrary/SwiftNetwork/Request+URLBuilding.swift
+++ b/Sources/GIGLibrary/SwiftNetwork/Request+URLBuilding.swift
@@ -1,0 +1,116 @@
+//
+//  Request+URLBuilding.swift
+//  GIGLibrary
+//
+//  URL assembly for `Request`: it joins `baseURL` and `endpoint` into a single, normalized path
+//  and appends `urlParams` as query items. Two correctness rules live here:
+//    - the base/endpoint separator is normalized to exactly one `/` (no `/v1items`, no `//`);
+//    - query values are converted by type rather than via `String(describing:)`, so arrays expand
+//      to repeated items and scalars never leak `Optional(...)`/`[1, 2]`-style text into the URL.
+//
+
+import Foundation
+
+extension Request {
+
+    /// Builds the final `URL`, throwing `.invalidURL` when the base/endpoint or the query items
+    /// cannot form a valid URL. Entry point used by `buildRequest()`.
+    func composeURL() throws -> URL {
+        guard let urlString = self.buildURL(), let url = self.addParams(to: URLComponents(string: urlString)) else {
+            self.logInvalidURLBuildError()
+            throw RequestBuildError.invalidURL
+        }
+        return url
+    }
+
+    /// Joins `baseURL` with the **path-only** `endpoint`. Returns `nil` (→ `.invalidURL`) when
+    /// `baseURL` is unparseable or has no scheme — an absolute URL is required. `endpoint` is treated
+    /// purely as a path component: any `?query`/`#fragment` it contains is percent-encoded into the
+    /// path, so query items must be passed via `urlParams` (or already present in `baseURL`).
+    private func buildURL() -> String? {
+        guard var components = URLComponents(string: self.baseURL), components.scheme != nil else {
+            return nil
+        }
+        components.path = self.normalizedPath(base: components.path, appending: self.endpoint)
+        // Assigning a path with reserved characters can make `string` nil; returning it as-is lets
+        // `composeURL` surface the failure as `.invalidURL` instead of crashing downstream.
+        return components.string
+    }
+
+    /// Joins `base` and `appending` with exactly one `/` separator: inserts one when neither side
+    /// supplies it (avoids `/v1items`) and collapses a duplicate when both do (avoids `//`).
+    private func normalizedPath(base: String, appending endpoint: String) -> String {
+        guard !endpoint.isEmpty else {
+            return base
+        }
+        guard !base.isEmpty else {
+            return endpoint.hasPrefix("/") ? endpoint : "/" + endpoint
+        }
+
+        switch (base.hasSuffix("/"), endpoint.hasPrefix("/")) {
+        case (true, true):
+            return base + endpoint.dropFirst()
+        case (false, false):
+            return base + "/" + endpoint
+        default:
+            return base + endpoint
+        }
+    }
+
+    private func addParams(to urlComponents: URLComponents?) -> URL? {
+        guard var urlComponents else { return nil }
+
+        if let urlParams = self.urlParams {
+            let newItems = urlParams.flatMap { key, value in
+                self.queryItems(name: key, value: value)
+            }
+            let urlConcat = concat(urlComponents.queryItems, newItems)
+            urlComponents.queryItems = urlConcat
+        }
+        guard let string = urlComponents.string else { return nil }
+        return URL(string: string)
+    }
+
+    /// Builds the query items for a single param. Arrays expand to one item per element under the
+    /// same name; every other value is converted explicitly (see `queryValue(for:)`) instead of
+    /// via `String(describing:)`, which leaks `Optional(...)`/`[1, 2]`-style text into the URL.
+    private func queryItems(name: String, value: Any) -> [URLQueryItem] {
+        if let array = value as? [Any] {
+            return array.map { URLQueryItem(name: name, value: self.queryValue(for: $0)) }
+        }
+        return [URLQueryItem(name: name, value: self.queryValue(for: value))]
+    }
+
+    private func queryValue(for value: Any) -> String? {
+        switch value {
+        case is NSNull:
+            return nil
+        case let string as String:
+            return string
+        case let number as NSNumber:
+            // Swift `Int`/`Double`/`Bool` and ObjC-bridged numbers all funnel here. CFBoolean
+            // identity separates a genuine boolean from a numeric 0/1: a bridged `NSNumber(0)`/`(1)`
+            // also satisfies `as? Bool`, so casting to `Bool` first would mangle those integers into
+            // "false"/"true". Genuine booleans render as "true"/"false"; numbers keep their canonical
+            // string form ("0", "1", "42", "1.5").
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                return number.boolValue ? "true" : "false"
+            }
+            return number.stringValue
+        default:
+            return String(describing: value)
+        }
+    }
+}
+
+func concat(_ lhs: [URLQueryItem]?, _ rhs: [URLQueryItem]?) -> [URLQueryItem] {
+    guard let left = lhs else {
+        return rhs ?? []
+    }
+
+    guard let right = rhs else {
+        return left
+    }
+
+    return left + right
+}

--- a/Sources/GIGLibrary/SwiftNetwork/Request+URLBuilding.swift
+++ b/Sources/GIGLibrary/SwiftNetwork/Request+URLBuilding.swift
@@ -75,13 +75,39 @@ extension Request {
     /// same name; every other value is converted explicitly (see `queryValue(for:)`) instead of
     /// via `String(describing:)`, which leaks `Optional(...)`/`[1, 2]`-style text into the URL.
     private func queryItems(name: String, value: Any) -> [URLQueryItem] {
-        if let array = value as? [Any] {
+        // `urlParams` is `[String: Any]`, so a caller can pass `Optional("x") as Any` or a nil
+        // optional. Unwrap it first: a nil optional becomes a single valueless item, and a wrapped
+        // value (incl. an optional array) is processed as if it had been passed directly.
+        guard let unwrapped = self.unwrapOptional(value) else {
+            return [URLQueryItem(name: name, value: nil)]
+        }
+        if let array = unwrapped as? [Any] {
             return array.map { URLQueryItem(name: name, value: self.queryValue(for: $0)) }
         }
-        return [URLQueryItem(name: name, value: self.queryValue(for: value))]
+        return [URLQueryItem(name: name, value: self.queryValue(for: unwrapped))]
+    }
+
+    /// Fully unwraps nested `Optional`s from an `Any`, returning `nil` if any level is `.none`.
+    private func unwrapOptional(_ value: Any) -> Any? {
+        var current = value
+        while true {
+            let mirror = Mirror(reflecting: current)
+            guard mirror.displayStyle == .optional else {
+                return current
+            }
+            guard let inner = mirror.children.first?.value else {
+                return nil
+            }
+            current = inner
+        }
     }
 
     private func queryValue(for value: Any) -> String? {
+        // Array elements (and any value) may themselves be optionals; unwrap before encoding so a
+        // nil optional drops its value instead of stringifying to "nil"/"Optional(...)".
+        guard let value = self.unwrapOptional(value) else {
+            return nil
+        }
         switch value {
         case is NSNull:
             return nil

--- a/Sources/GIGLibrary/SwiftNetwork/Request.swift
+++ b/Sources/GIGLibrary/SwiftNetwork/Request.swift
@@ -9,13 +9,13 @@
 import Foundation
 import os
 
-public enum StandardType {
+public enum StandardType: Sendable {
     case gigigo
     case basic
 }
 
 /// See https://tools.ietf.org/html/rfc7231#section-4.3
-public enum HTTPMethod: String {
+public enum HTTPMethod: String, Sendable {
     case get     = "GET"
     case post    = "POST"
     case put     = "PUT"
@@ -41,7 +41,9 @@ public struct FileUploadData {
     }
 }
 
-private enum RequestBuildError: Error {
+// `internal` (not `private`) so `Request+URLBuilding.swift` can throw `.invalidURL` from the
+// extracted URL-composition helpers.
+enum RequestBuildError: Error {
     case invalidURL
     case bodyEncodingFailed
     case noInternet
@@ -233,9 +235,11 @@ public class Request: Selfie, @unchecked Sendable {
         do {
             try self.preChecks()
             let request = try self.buildRequest()
-            let (session, generation) = try self.prepareSession(for: request, applyCache: true)
+            let (session, generation, ownsSession) = try self.prepareSession(for: request, applyCache: true)
             defer {
-                session.finishTasksAndInvalidate()
+                if ownsSession {
+                    session.finishTasksAndInvalidate()
+                }
             }
 
             let operation = Task { try await session.data(for: request) }
@@ -319,9 +323,11 @@ public class Request: Selfie, @unchecked Sendable {
         do {
             try self.preChecks()
             let request = try self.buildRequest()
-            let (session, generation) = try self.prepareSession(for: request, applyCache: false)
+            let (session, generation, ownsSession) = try self.prepareSession(for: request, applyCache: false)
             defer {
-                session.finishTasksAndInvalidate()
+                if ownsSession {
+                    session.finishTasksAndInvalidate()
+                }
             }
 
             let operation = Task { try await session.download(for: request) }
@@ -362,9 +368,11 @@ public class Request: Selfie, @unchecked Sendable {
         do {
             try self.preChecks()
             let (request, bodyData) = try self.buildUploadRequest(files: files, params: params)
-            let (session, generation) = try self.prepareSession(for: request, bodyForLog: bodyData, applyCache: false)
+            let (session, generation, ownsSession) = try self.prepareSession(for: request, bodyForLog: bodyData, applyCache: false)
             defer {
-                session.finishTasksAndInvalidate()
+                if ownsSession {
+                    session.finishTasksAndInvalidate()
+                }
             }
 
             let operation = Task { try await session.upload(for: request, from: bodyData) }
@@ -409,9 +417,12 @@ public class Request: Selfie, @unchecked Sendable {
         }
     }
 
-    private func configuredSession(applyCache: Bool) -> URLSession {
+    /// Returns the session to use plus whether this instance *owns* it. An injected `self.session`
+    /// is owned by the caller and may back other in-flight tasks, so the fetch flow must never
+    /// invalidate it; only sessions created here are torn down with `finishTasksAndInvalidate()`.
+    private func configuredSession(applyCache: Bool) -> (session: URLSession, ownsSession: Bool) {
         if let session = self.session {
-            return session
+            return (session, false)
         }
 
         let configuration = self.sessionConfiguration ?? URLSessionConfiguration.default
@@ -420,7 +431,8 @@ public class Request: Selfie, @unchecked Sendable {
         if applyCache {
             self.controlCache(config: configuration)
         }
-        return URLSession(configuration: configuration, delegate: self as? URLSessionDelegate, delegateQueue: nil)
+        let session = URLSession(configuration: configuration, delegate: self as? URLSessionDelegate, delegateQueue: nil)
+        return (session, true)
     }
 
     private func logIfVerbose(_ response: Response) {
@@ -432,6 +444,13 @@ public class Request: Selfie, @unchecked Sendable {
     private func logRequestError(message: String) {
         guard self.verbose else { return }
         self.networkLogManager.log(message, info: self.logInfo)
+    }
+
+    // `internal` (not `private`) so `composeURL` in `Request+URLBuilding.swift` can report an
+    // unbuildable URL; the logging state it touches (`networkLogManager`, `logInfo`) is private.
+    func logInvalidURLBuildError() {
+        guard self.verbose else { return }
+        self.networkLogManager.log("not a valid URL", info: self.logInfo)
     }
 
     private func preChecks() throws {
@@ -475,7 +494,7 @@ public class Request: Selfie, @unchecked Sendable {
         for request: URLRequest,
         bodyForLog: Data? = nil,
         applyCache: Bool
-    ) throws -> (session: URLSession, generation: Int) {
+    ) throws -> (session: URLSession, generation: Int, ownsSession: Bool) {
         var requestForLog = request
         if let bodyForLog {
             requestForLog.httpBody = bodyForLog
@@ -486,16 +505,19 @@ public class Request: Selfie, @unchecked Sendable {
         // configured — so a superseding `fetch()` tears the previous one down without a timing shift.
         let generation = self.beginCancellationScope()
 
-        let session = self.configuredSession(applyCache: applyCache)
+        let (session, ownsSession) = self.configuredSession(applyCache: applyCache)
         if Task.isCancelled {
             // The caller installs `defer { session.finishTasksAndInvalidate() }` only on the
             // returned value, so invalidate here before throwing or this session (and the delegate
-            // it retains) would leak until ARC reclaims it.
-            session.finishTasksAndInvalidate()
+            // it retains) would leak until ARC reclaims it. Only sessions we created may be
+            // invalidated — an injected session is the caller's to manage.
+            if ownsSession {
+                session.finishTasksAndInvalidate()
+            }
             self.logRequestError(message: "Request cancelled before execution.")
             throw RequestBuildError.cancelledBeforeExecution
         }
-        return (session, generation)
+        return (session, generation, ownsSession)
     }
 
     private func buildUploadRequest(
@@ -518,14 +540,6 @@ public class Request: Selfie, @unchecked Sendable {
         var request = self.composeBaseRequest(url: url)
         try self.applyBodyAndContentTypeIfNeeded(to: &request)
         return request
-    }
-
-    private func composeURL() throws -> URL {
-        guard let urlString = self.buildURL(), let url = self.addParams(to: URLComponents(string: urlString)) else {
-            self.logInvalidURLBuildError()
-            throw RequestBuildError.invalidURL
-        }
-        return url
     }
 
     private func composeBaseRequest(url: URL) -> URLRequest {
@@ -587,31 +601,6 @@ public class Request: Selfie, @unchecked Sendable {
         }
     }
 
-    private func logInvalidURLBuildError() {
-        guard self.verbose else { return }
-        self.networkLogManager.log("not a valid URL", info: self.logInfo)
-    }
-
-    fileprivate func addParams(to urlComponents: URLComponents?) -> URL? {
-        guard var urlComponents else { return nil }
-        
-        if let urlParams = self.urlParams?.map({ key, value in
-            URLQueryItem(name: key, value: String(describing: value))
-        }) {
-            let urlConcat = concat(urlComponents.queryItems, urlParams)
-            urlComponents.queryItems = urlConcat
-        }
-        guard let string = urlComponents.string else { return nil }
-        return URL(string: string)
-    }
-    
-    fileprivate func buildURL() -> String? {
-        var url = URLComponents(string: self.baseURL)
-        url?.path += self.endpoint
-        
-        return url?.string
-    }
-	
 	fileprivate func logRequest(_ request: URLRequest) {
         guard self.verbose else { return }
 
@@ -667,16 +656,4 @@ public class Request: Selfie, @unchecked Sendable {
         data.append(boundaryData)
         return data
     }
-}
-
-func concat(_ lhs: [URLQueryItem]?, _ rhs: [URLQueryItem]?) -> [URLQueryItem] {
-	guard let left = lhs else {
-		return rhs ?? []
-	}
-	
-	guard let right = rhs else {
-		return left
-	}
-	
-	return left + right
 }

--- a/Sources/GIGLibrary/SwiftNetwork/Response.swift
+++ b/Sources/GIGLibrary/SwiftNetwork/Response.swift
@@ -30,15 +30,23 @@ public enum ResponseError: Error {
 	case unexpectedDataType
 }
 
+/// `@unchecked Sendable` is sound by design under one invariant: a `Response` is fully populated
+/// inside `init` (including the `parseJSON`/`parseError` it drives) and is never mutated afterwards.
+/// `fetch()` constructs it, returns it, and hands ownership to the caller without retaining a
+/// mutable reference — so although it crosses a concurrency boundary, only one context ever touches
+/// it at a time. Every stored property is therefore exposed as `public private(set)`: consumers read
+/// it, no one outside the type can mutate it post-init. `data` is a `JSON` (a mutable reference
+/// type); it too is built during `init` and neither shared nor mutated afterwards. Hardening `JSON`
+/// itself into a value/Sendable type is tracked separately (C048).
 public class Response: Selfie, @unchecked Sendable {
-	
-	public var status: ResponseStatus
-	public var statusCode: Int
-	public var url: URL?
-	public var headers: [AnyHashable: Any]?
-	public var body: Data?
-	public var data: JSON?
-	public var error: NSError?
+
+	public private(set) var status: ResponseStatus
+	public private(set) var statusCode: Int
+	public private(set) var url: URL?
+	public private(set) var headers: [AnyHashable: Any]?
+	public private(set) var body: Data?
+	public private(set) var data: JSON?
+	public private(set) var error: NSError?
 
 	private var networkLogManager: NetworkLogManaging
     private var standardType: StandardType = .gigigo
@@ -58,15 +66,15 @@ public class Response: Selfie, @unchecked Sendable {
 			self.body = data
 			self.statusCode = response.statusCode
 			
-			if (200...300).contains(self.statusCode) {
+			if (200..<300).contains(self.statusCode) {
 				self.status = .success
 			}
-			
+
             if self.shouldParseJSON(headers: self.headers, body: self.body) {
                 self.parseJSON()
             }
 
-            if !(200...300).contains(self.statusCode), self.status == .unknownError {
+            if !(200..<300).contains(self.statusCode), self.status == .unknownError {
                 let fallbackError = NSError(
                     domain: kGIGNetworkErrorDomain,
                     code: self.statusCode,
@@ -104,7 +112,18 @@ public class Response: Selfie, @unchecked Sendable {
 		guard let imageData = self.body else {
 			throw ResponseError.bodyNil
 		}
-        guard !isGifData(), let image = UIImage(data: imageData, scale: UIScreen.main.scale) else {
+
+        // GIFs need the animated decoder: `UIImage(data:)` only yields the first frame, and the
+        // previous code rejected them outright — so a managed download (e.g. `ImageDownloader`)
+        // spent a network slot only to discard the result silently. Decode them properly here.
+        if self.isGifURL() {
+            guard let image = UIImage.gif(data: imageData) else {
+                throw ResponseError.unexpectedDataType
+            }
+            return image
+        }
+
+        guard let image = UIImage(data: imageData, scale: UIScreen.main.scale) else {
             throw ResponseError.unexpectedDataType
         }
         return image
@@ -143,11 +162,11 @@ public class Response: Selfie, @unchecked Sendable {
 
     // MARK: - Private Helpers
     
-    private func isGifData() -> Bool {
+    private func isGifURL() -> Bool {
         guard let url else {
             return false
         }
-        return url.pathExtension == "gif"
+        return url.pathExtension.caseInsensitiveCompare("gif") == .orderedSame
     }
 
     private func shouldParseJSON(headers: [AnyHashable: Any]?, body: Data?) -> Bool {

--- a/Sources/GIGLibrary/SwiftNetwork/Response.swift
+++ b/Sources/GIGLibrary/SwiftNetwork/Response.swift
@@ -78,12 +78,14 @@ public class Response: Selfie, @unchecked Sendable {
             // `.success`, even when a Gigigo envelope claims `status: true`/`"OK"` (which
             // `parseJSON()` would otherwise honour). If body parsing already mapped a specific
             // error (`.apiError`, `.sessionExpired`, …) keep it; only override a still-unknown or
-            // wrongly-successful status with a synthesized HTTP error.
-            if !(200..<300).contains(self.statusCode), self.status == .unknownError || self.status == .success {
+            // wrongly-successful status with a synthesized HTTP error. Use the transport code from
+            // `response` directly — `parseError(json:)` may have overwritten `self.statusCode` with
+            // the envelope's application error code, which would lose the real HTTP status here.
+            if !(200..<300).contains(response.statusCode), self.status == .unknownError || self.status == .success {
                 let fallbackError = NSError(
                     domain: kGIGNetworkErrorDomain,
-                    code: self.statusCode,
-                    message: "HTTP error \(self.statusCode)"
+                    code: response.statusCode,
+                    message: "HTTP error \(response.statusCode)"
                 )
                 self.error = fallbackError
                 self.status = self.parseError(error: fallbackError)
@@ -112,8 +114,12 @@ public class Response: Selfie, @unchecked Sendable {
 		return json
 	}
 	
-    @MainActor
-    func image() throws -> UIImage {
+    /// Decodes the response body into a `UIImage`. `nonisolated` and scale-injected on purpose: a
+    /// `.gif` body can carry many/large frames and is network-controlled, so the (potentially heavy)
+    /// decode must run off the main actor — `ImageDownloader` reads the scale on the main actor and
+    /// then calls this from a detached task. GIFs decode as animated images; everything else as a
+    /// single frame at `scale`.
+    func image(scale: CGFloat) throws -> UIImage {
 		guard let imageData = self.body else {
 			throw ResponseError.bodyNil
 		}
@@ -128,7 +134,7 @@ public class Response: Selfie, @unchecked Sendable {
             return image
         }
 
-        guard let image = UIImage(data: imageData, scale: UIScreen.main.scale) else {
+        guard let image = UIImage(data: imageData, scale: scale) else {
             throw ResponseError.unexpectedDataType
         }
         return image

--- a/Sources/GIGLibrary/SwiftNetwork/Response.swift
+++ b/Sources/GIGLibrary/SwiftNetwork/Response.swift
@@ -74,7 +74,12 @@ public class Response: Selfie, @unchecked Sendable {
                 self.parseJSON()
             }
 
-            if !(200..<300).contains(self.statusCode), self.status == .unknownError {
+            // The HTTP status is authoritative: a non-2xx response must never be reported as
+            // `.success`, even when a Gigigo envelope claims `status: true`/`"OK"` (which
+            // `parseJSON()` would otherwise honour). If body parsing already mapped a specific
+            // error (`.apiError`, `.sessionExpired`, …) keep it; only override a still-unknown or
+            // wrongly-successful status with a synthesized HTTP error.
+            if !(200..<300).contains(self.statusCode), self.status == .unknownError || self.status == .success {
                 let fallbackError = NSError(
                     domain: kGIGNetworkErrorDomain,
                     code: self.statusCode,

--- a/Tests/GIGLibraryTests/GIGUtils/ImageDownloaderTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/ImageDownloaderTests.swift
@@ -196,6 +196,26 @@ struct ImageDownloaderTests {
         #expect(networkHits.value == 1)
     }
 
+    @Test("Given an animated GIF response, when downloaded, then the cached image stays animated (resize must not flatten it)")
+    func gifDownloadStaysAnimated() async {
+        ImageDownloader.resetForTesting()
+        let urlString = "https://example.com/anim.gif"
+        // Minimal 1x1 GIF89a — decodes to an animated UIImage (`images != nil`). The resize step
+        // would flatten it to a single static frame if it weren't skipped for animated images.
+        let gifData = Data(base64Encoded: "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7") ?? Data()
+        ImageDownloader.fetchProvider = { _ in
+            makeImageResponse(body: gifData, url: URL(string: urlString) ?? URL(fileURLWithPath: "/anim.gif"))
+        }
+
+        let view = makeImageView()
+        ImageDownloader.shared.download(url: urlString, for: view, placeholder: nil)
+
+        let cached = await waitUntil { ImageDownloader.images[urlString] != nil }
+        #expect(cached)
+        #expect(ImageDownloader.images[urlString]?.images != nil)
+        #expect(ImageDownloader.activeDownloads == 0)
+    }
+
     // MARK: - Cache hit
 
     @Test("Given a cached URL, when requested, then no download starts and the cached image is assigned")

--- a/Tests/GIGLibraryTests/SwiftNetwork/RequestTests.swift
+++ b/Tests/GIGLibraryTests/SwiftNetwork/RequestTests.swift
@@ -670,4 +670,191 @@ struct RequestTests {
         #expect(message.contains("\"id\" : 1"))
         #expect(message.contains("\"id\" : 2"))
     }
+
+    @Test("Given a base URL without a trailing slash and an endpoint without a leading slash, when fetch is called, then a single separator is inserted")
+    func fetchInsertsSeparatorBetweenBaseAndEndpoint() async throws {
+        // Given
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.respond(path: "/api/v1/items") { request in
+            capturedRequest = request
+        }
+
+        let request = Request.testRequest(
+            baseUrl: "https://example.com/api",
+            endpoint: "v1/items"
+        )
+
+        // When
+        _ = await request.fetch()
+
+        // Then
+        let urlRequest = try #require(capturedRequest)
+        let requestURL = try #require(urlRequest.url)
+        let components = try #require(URLComponents(url: requestURL, resolvingAgainstBaseURL: false))
+
+        #expect(components.path == "/api/v1/items")
+    }
+
+    @Test("Given a base URL with a trailing slash and an endpoint with a leading slash, when fetch is called, then the duplicate separator is collapsed")
+    func fetchCollapsesDoubleSeparatorBetweenBaseAndEndpoint() async throws {
+        // Given
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.respond(path: "/api/v1/items") { request in
+            capturedRequest = request
+        }
+
+        let request = Request.testRequest(
+            baseUrl: "https://example.com/api/",
+            endpoint: "/v1/items"
+        )
+
+        // When
+        _ = await request.fetch()
+
+        // Then
+        let urlRequest = try #require(capturedRequest)
+        let requestURL = try #require(urlRequest.url)
+        let components = try #require(URLComponents(url: requestURL, resolvingAgainstBaseURL: false))
+
+        #expect(components.path == "/api/v1/items")
+    }
+
+    @Test("Given URL params with an array and typed scalars, when fetch is called, then arrays expand and values are encoded by type")
+    func fetchEncodesUrlParamsByType() async throws {
+        // Given
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.respond(path: "/typed-params") { request in
+            capturedRequest = request
+        }
+
+        let request = Request.testRequest(
+            baseUrl: "https://example.com",
+            endpoint: "/typed-params",
+            urlParams: [
+                "tags": ["swift", "ios"],
+                "count": 3,
+                "ratio": 1.5,
+                "enabled": true,
+                "name": "value"
+            ]
+        )
+
+        // When
+        _ = await request.fetch()
+
+        // Then
+        let urlRequest = try #require(capturedRequest)
+        let requestURL = try #require(urlRequest.url)
+        let components = try #require(URLComponents(url: requestURL, resolvingAgainstBaseURL: false))
+        let queryItems = components.queryItems ?? []
+        let values = { (name: String) in
+            queryItems.filter { $0.name == name }.compactMap { $0.value }
+        }
+
+        #expect(Set(values("tags")) == ["swift", "ios"])
+        #expect(values("count") == ["3"])
+        #expect(values("ratio") == ["1.5"])
+        #expect(values("enabled") == ["true"])
+        #expect(values("name") == ["value"])
+        // Regression guard: arrays must not serialize as a single "[swift, ios]" item.
+        #expect(values("tags").contains(where: { $0.contains("[") }) == false)
+    }
+
+    @Test("Given URL params bridged from JSON plus NSNull, when fetch is called, then bridged bool/number encode by type and NSNull is a valueless item")
+    func fetchEncodesBridgedAndNullUrlParams() async throws {
+        // Given params carrying ObjC-bridged types: JSONSerialization yields __NSCFBoolean / __NSCFNumber,
+        // which is where the Bool-vs-Int casting ambiguity would bite if the switch order were wrong.
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.respond(path: "/bridged-params") { request in
+            capturedRequest = request
+        }
+
+        let bridged = try #require(
+            try JSONSerialization.jsonObject(
+                with: Data(#"{"flag": true, "zero": 0, "one": 1, "n": 7}"#.utf8)
+            ) as? [String: Any]
+        )
+        var params = bridged
+        params["missing"] = NSNull()
+
+        let request = Request.testRequest(
+            baseUrl: "https://example.com",
+            endpoint: "/bridged-params",
+            urlParams: params
+        )
+
+        // When
+        _ = await request.fetch()
+
+        // Then
+        let urlRequest = try #require(capturedRequest)
+        let requestURL = try #require(urlRequest.url)
+        let components = try #require(URLComponents(url: requestURL, resolvingAgainstBaseURL: false))
+        let queryItems = components.queryItems ?? []
+        let item = { (name: String) in queryItems.first(where: { $0.name == name }) }
+
+        #expect(item("flag")?.value == "true")
+        // Regression guard: bridged integer 0/1 must stay "0"/"1", never "false"/"true".
+        #expect(item("zero")?.value == "0")
+        #expect(item("one")?.value == "1")
+        #expect(item("n")?.value == "7")
+        // NSNull maps to a nil value: the key is present without an `=value`.
+        #expect(queryItems.contains(where: { $0.name == "missing" }))
+        #expect(item("missing")?.value == nil)
+    }
+
+    @Test("Given a base URL without a scheme, when fetch is called, then it returns an invalid URL response and does not send the request")
+    func fetchReturnsInvalidUrlForSchemelessBaseUrl() async {
+        // Given
+        var didReceiveRequest = false
+
+        MockURLProtocol.respond(path: "/schemeless") { _ in
+            didReceiveRequest = true
+        }
+
+        let request = Request.testRequest(
+            baseUrl: "example.com",
+            endpoint: "/schemeless"
+        )
+
+        // When
+        let response = await request.fetch()
+
+        // Then
+        #expect(response.status == .unknownError)
+        #expect(response.error?.code == URLError.badURL.rawValue)
+        #expect(didReceiveRequest == false)
+    }
+
+    @Test("Given a caller-injected URLSession, when fetch is called more than once, then the session is not invalidated and every call succeeds")
+    func fetchDoesNotInvalidateInjectedSession() async {
+        // Given a caller-owned session (C060: the fetch flow must not finishTasksAndInvalidate it,
+        // unlike the sessions it creates internally from a sessionConfiguration).
+        MockURLProtocol.respond(path: "/injected-session") { _ in }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        defer { session.invalidateAndCancel() }
+
+        let request = Request(
+            baseUrl: "https://example.com",
+            endpoint: "/injected-session",
+            session: session,
+            reachability: MockReachabilityProvider(reachable: true)
+        )
+
+        // When the same caller-owned session is reused across two fetches
+        let first = await request.fetch()
+        let second = await request.fetch()
+
+        // Then it was never invalidated — both calls reach the network and succeed. With the bug
+        // (invalidating an injected session), the second fetch would fail on a dead session.
+        #expect(first.status == .success)
+        #expect(second.status == .success)
+    }
 }

--- a/Tests/GIGLibraryTests/SwiftNetwork/RequestTests.swift
+++ b/Tests/GIGLibraryTests/SwiftNetwork/RequestTests.swift
@@ -807,6 +807,38 @@ struct RequestTests {
         #expect(item("missing")?.value == nil)
     }
 
+    @Test("Given non-finite Double URL params, when fetch is called, then they are not serialized as nan/inf text")
+    func fetchDropsNonFiniteDoubleUrlParams() async throws {
+        // Given
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.respond(path: "/non-finite") { request in
+            capturedRequest = request
+        }
+
+        let request = Request.testRequest(
+            baseUrl: "https://example.com",
+            endpoint: "/non-finite",
+            urlParams: ["a": Double.nan, "b": Double.infinity, "ok": 1.5]
+        )
+
+        // When
+        _ = await request.fetch()
+
+        // Then
+        let urlRequest = try #require(capturedRequest)
+        let requestURL = try #require(urlRequest.url)
+        let components = try #require(URLComponents(url: requestURL, resolvingAgainstBaseURL: false))
+        let queryItems = components.queryItems ?? []
+        let item = { (name: String) in queryItems.first(where: { $0.name == name }) }
+
+        // Non-finite doubles become valueless items, never "nan"/"inf" garbage; finite values pass through.
+        #expect(item("a")?.value == nil)
+        #expect(item("b")?.value == nil)
+        #expect(item("ok")?.value == "1.5")
+        #expect(queryItems.allSatisfy { ($0.value ?? "") != "nan" && ($0.value ?? "") != "inf" })
+    }
+
     @Test("Given a base URL without a scheme, when fetch is called, then it returns an invalid URL response and does not send the request")
     func fetchReturnsInvalidUrlForSchemelessBaseUrl() async {
         // Given

--- a/Tests/GIGLibraryTests/SwiftNetwork/RequestTests.swift
+++ b/Tests/GIGLibraryTests/SwiftNetwork/RequestTests.swift
@@ -839,6 +839,54 @@ struct RequestTests {
         #expect(queryItems.allSatisfy { ($0.value ?? "") != "nan" && ($0.value ?? "") != "inf" })
     }
 
+    @Test("Given optional URL param values, when fetch is called, then they are unwrapped, not stringified as Optional(...)/nil")
+    func fetchUnwrapsOptionalUrlParams() async throws {
+        // Given values that arrive as Optionals through the [String: Any] box
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.respond(path: "/optionals") { request in
+            capturedRequest = request
+        }
+
+        let some: String? = "abc"
+        let none: String? = nil
+        let someInt: Int? = 7
+        let optionalArray: [Int]? = [1, 2]
+
+        let request = Request.testRequest(
+            baseUrl: "https://example.com",
+            endpoint: "/optionals",
+            urlParams: [
+                "a": some as Any,
+                "b": none as Any,
+                "c": someInt as Any,
+                "tags": optionalArray as Any
+            ]
+        )
+
+        // When
+        _ = await request.fetch()
+
+        // Then
+        let urlRequest = try #require(capturedRequest)
+        let requestURL = try #require(urlRequest.url)
+        let components = try #require(URLComponents(url: requestURL, resolvingAgainstBaseURL: false))
+        let queryItems = components.queryItems ?? []
+        let item = { (name: String) in queryItems.first(where: { $0.name == name }) }
+
+        #expect(item("a")?.value == "abc")
+        #expect(item("c")?.value == "7")
+        // Optional-wrapped array still expands.
+        #expect(Set(queryItems.filter { $0.name == "tags" }.compactMap { $0.value }) == ["1", "2"])
+        // nil optional → valueless item, never "nil"/"Optional(...)".
+        #expect(queryItems.contains { $0.name == "b" })
+        #expect(item("b")?.value == nil)
+        #expect(queryItems.allSatisfy { v in
+            let s = v.value ?? ""
+            return !s.contains("Optional") && s != "nil"
+        })
+    }
+
     @Test("Given a base URL without a scheme, when fetch is called, then it returns an invalid URL response and does not send the request")
     func fetchReturnsInvalidUrlForSchemelessBaseUrl() async {
         // Given

--- a/Tests/GIGLibraryTests/SwiftNetwork/ResponseTests.swift
+++ b/Tests/GIGLibraryTests/SwiftNetwork/ResponseTests.swift
@@ -217,8 +217,8 @@ struct ResponseTests {
         }
     }
 
-    @Test("Given a GIF URL, when image is requested, then it throws unexpectedDataType")
-    func imageThrowsWhenGifURL() throws {
+    @Test("Given a GIF URL with undecodable data, when image is requested, then it throws unexpectedDataType")
+    func imageThrowsWhenGifDataIsInvalid() throws {
         // Given
         let url = try #require(URL(string: "https://example.com/animated.gif"))
         let response = makeImageResponse(body: Data([0x00, 0x01, 0x02]), url: url)
@@ -226,6 +226,47 @@ struct ResponseTests {
         // When/Then
         assertThrowsResponseError(.unexpectedDataType) {
             _ = try response.image()
+        }
+    }
+
+    @Test("Given a GIF URL with valid GIF data, when image is requested, then it returns a decoded image")
+    func imageDecodesValidGifData() throws {
+        // Given a minimal 1x1 transparent GIF89a
+        let gifData = try #require(Data(base64Encoded: "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"))
+        let url = try #require(URL(string: "https://example.com/animated.gif"))
+        let response = makeImageResponse(body: gifData, url: url)
+
+        // When
+        let image = try response.image()
+
+        // Then it went through the animated GIF decoder (UIImage.gif), not the single-frame fallback
+        #expect(image.images != nil)
+        #expect(image.size.width > 0)
+        #expect(image.size.height > 0)
+    }
+
+    @Test("Given HTTP status codes around the 2xx boundary, when Response parses, then only 200..<300 are success")
+    func responseTreatsOnly2xxAsSuccess() throws {
+        // Given
+        let url = try #require(URL(string: "https://example.com"))
+        let cases: [(code: Int, isSuccess: Bool)] = [
+            (199, false),
+            (200, true),
+            (204, true),
+            (299, true),
+            (300, false),
+            (301, false)
+        ]
+
+        for testCase in cases {
+            let httpResponse = HTTPURLResponse.fake(url: url, statusCode: testCase.code, headers: nil)
+
+            // When
+            let response = Response(data: nil, response: httpResponse, error: nil)
+
+            // Then
+            #expect((response.status == .success) == testCase.isSuccess)
+            #expect(response.statusCode == testCase.code)
         }
     }
 

--- a/Tests/GIGLibraryTests/SwiftNetwork/ResponseTests.swift
+++ b/Tests/GIGLibraryTests/SwiftNetwork/ResponseTests.swift
@@ -213,7 +213,7 @@ struct ResponseTests {
 
         // When/Then
         assertThrowsResponseError(.bodyNil) {
-            _ = try response.image()
+            _ = try response.image(scale: 1)
         }
     }
 
@@ -225,7 +225,7 @@ struct ResponseTests {
 
         // When/Then
         assertThrowsResponseError(.unexpectedDataType) {
-            _ = try response.image()
+            _ = try response.image(scale: 1)
         }
     }
 
@@ -237,7 +237,7 @@ struct ResponseTests {
         let response = makeImageResponse(body: gifData, url: url)
 
         // When
-        let image = try response.image()
+        let image = try response.image(scale: 1)
 
         // Then it went through the animated GIF decoder (UIImage.gif), not the single-frame fallback
         #expect(image.images != nil)
@@ -312,6 +312,27 @@ struct ResponseTests {
         #expect(response.error?.code == 15001)
     }
 
+    @Test("Given a non-2xx Gigigo error envelope whose code does not map to a status, when Response parses, then the synthesized error uses the real HTTP code")
+    func responseNon2xxUnmappedErrorEnvelopeUsesHttpCode() throws {
+        // Given HTTP 400 with an application error code (1001) that maps to no specific status
+        let url = try #require(URL(string: "https://example.com"))
+        let body: [String: Any] = ["status": false, "error": ["code": 1001, "message": "Bad request"]]
+        let data = try JSONSerialization.data(withJSONObject: body, options: [])
+        let httpResponse = HTTPURLResponse.fake(
+            url: url,
+            statusCode: 400,
+            headers: ["Content-Type": "application/json"]
+        )
+
+        // When
+        let response = Response(data: data, response: httpResponse, error: nil, standardType: .gigigo)
+
+        // Then the transport status (400) is preserved, not the envelope code (1001)
+        #expect(response.status != .success)
+        #expect(response.statusCode == 400)
+        #expect(response.error?.code == 400)
+    }
+
     @Test("Given a non-2xx response carrying a Gigigo envelope with status OK string, when Response parses, then the HTTP status wins and it is not success")
     func responseNon2xxWithOkStringEnvelopeIsNotSuccess() throws {
         // Given a 400 whose envelope claims success via the string form ("OK", not boolean true)
@@ -361,7 +382,7 @@ struct ResponseTests {
 
         // When/Then
         assertThrowsResponseError(.unexpectedDataType) {
-            _ = try response.image()
+            _ = try response.image(scale: 1)
         }
     }
 

--- a/Tests/GIGLibraryTests/SwiftNetwork/ResponseTests.swift
+++ b/Tests/GIGLibraryTests/SwiftNetwork/ResponseTests.swift
@@ -270,6 +270,89 @@ struct ResponseTests {
         }
     }
 
+    @Test("Given a non-2xx response carrying a Gigigo success envelope, when Response parses, then the HTTP status wins and it is not success")
+    func responseNon2xxWithSuccessEnvelopeIsNotSuccess() throws {
+        // Given a 400 whose body still claims success the Gigigo way
+        let url = try #require(URL(string: "https://example.com"))
+        let body: [String: Any] = ["status": true, "data": ["id": 1]]
+        let data = try JSONSerialization.data(withJSONObject: body, options: [])
+        let httpResponse = HTTPURLResponse.fake(
+            url: url,
+            statusCode: 400,
+            headers: ["Content-Type": "application/json"]
+        )
+
+        // When
+        let response = Response(data: data, response: httpResponse, error: nil, standardType: .gigigo)
+
+        // Then the non-2xx HTTP status is authoritative
+        #expect(response.status != .success)
+        #expect(response.statusCode == 400)
+        #expect(response.error?.domain == kGIGNetworkErrorDomain)
+    }
+
+    @Test("Given a non-2xx response with a Gigigo error envelope, when Response parses, then the specific API error is preserved")
+    func responseNon2xxWithErrorEnvelopeKeepsApiError() throws {
+        // Given a 400 carrying a Gigigo error envelope: the specific error must not be clobbered
+        let url = try #require(URL(string: "https://example.com"))
+        let body: [String: Any] = ["status": false, "error": ["code": 15001, "message": "Bad"]]
+        let data = try JSONSerialization.data(withJSONObject: body, options: [])
+        let httpResponse = HTTPURLResponse.fake(
+            url: url,
+            statusCode: 400,
+            headers: ["Content-Type": "application/json"]
+        )
+
+        // When
+        let response = Response(data: data, response: httpResponse, error: nil, standardType: .gigigo)
+
+        // Then
+        #expect(response.status == .apiError)
+        #expect(response.statusCode == 15001)
+        #expect(response.error?.code == 15001)
+    }
+
+    @Test("Given a non-2xx response carrying a Gigigo envelope with status OK string, when Response parses, then the HTTP status wins and it is not success")
+    func responseNon2xxWithOkStringEnvelopeIsNotSuccess() throws {
+        // Given a 400 whose envelope claims success via the string form ("OK", not boolean true)
+        let url = try #require(URL(string: "https://example.com"))
+        let body: [String: Any] = ["status": "OK", "data": ["id": 1]]
+        let data = try JSONSerialization.data(withJSONObject: body, options: [])
+        let httpResponse = HTTPURLResponse.fake(
+            url: url,
+            statusCode: 400,
+            headers: ["Content-Type": "application/json"]
+        )
+
+        // When
+        let response = Response(data: data, response: httpResponse, error: nil, standardType: .gigigo)
+
+        // Then
+        #expect(response.status != .success)
+        #expect(response.statusCode == 400)
+    }
+
+    @Test("Given a non-2xx basic-standard JSON response, when Response parses, then it is not success even though the body parsed")
+    func responseNon2xxBasicJsonIsNotSuccess() throws {
+        // Given a 400 with a plain JSON body parsed under the basic standard type
+        let url = try #require(URL(string: "https://example.com"))
+        let body: [String: Any] = ["message": "nope"]
+        let data = try JSONSerialization.data(withJSONObject: body, options: [])
+        let httpResponse = HTTPURLResponse.fake(
+            url: url,
+            statusCode: 400,
+            headers: ["Content-Type": "application/json"]
+        )
+
+        // When
+        let response = Response(data: data, response: httpResponse, error: nil, standardType: .basic)
+
+        // Then the HTTP error wins; the parsed body remains available behind the error status
+        #expect(response.status != .success)
+        #expect(response.statusCode == 400)
+        #expect(response.data?.toDictionary()?["message"] as? String == "nope")
+    }
+
     @Test("Given invalid image data, when image is requested, then it throws unexpectedDataType")
     func imageThrowsWhenDataIsInvalid() throws {
         // Given


### PR DESCRIPTION
Sesión **S1** de la auditoría de release de GIGLibrary. Agrupa 7 hallazgos en el módulo `SwiftNetwork` (`Request.swift` / `Response.swift`) en una sola rama por compartir archivos. Verificado con revisión iterativa de PR (subagentes limpios) hasta converger sin hallazgos.

## Qué cambia

| ID | Tipo | Cambio |
|----|------|--------|
| **C024** | bug | El rango de éxito HTTP era `(200...300)`, marcando el `300` (redirección 3xx) como `.success`. Ahora `(200..<300)` en ambas comprobaciones. |
| **C061** | bug | `buildURL` concatenaba `baseURL.path + endpoint` tal cual (`/v1items`, `//`). Ahora normaliza el separador a exactamente un `/`, exige `baseURL` absoluta con esquema (→ `.invalidURL`) y trata `endpoint` como solo-path. |
| **C062** | bug | Los query params usaban `String(describing:)` (arrays → `[1, 2]`, opcionales → `Optional(...)`). Ahora se convierten por tipo y los arrays se expanden a múltiples `URLQueryItem`. **Además** se distingue el booleano genuino de un `NSNumber(0/1)` bridgeado por identidad `CFBoolean` (si no, `offset=0`/`page=1` provenientes de `JSONSerialization`/`NSDictionary` se corrompían a `false`/`true`). |
| **C060** | concurrency | `configuredSession` devolvía la sesión inyectada tal cual y luego el `defer` la invalidaba con `finishTasksAndInvalidate()`, rompiendo sesiones del llamante. Ahora se rastrea la propiedad (`ownsSession`) y solo se invalidan las creadas internamente. |
| **C051** | correctness | `Response.image()` rechazaba toda URL `.gif`, gastando red y un slot del `ImageDownloader` para descartar en silencio. Ahora decodifica GIFs con `UIImage.gif(data:)`. `isGifData()` → `isGifURL()` (case-insensitive). |
| **C065** | concurrency | `Response` es `@unchecked Sendable` pero exponía todo el estado como `public var`. Reducido a `public private(set) var` (inmutable post-init) y documentada la invariante que hace sólida la conformidad. |
| **C041** | concurrency | `Sendable` en `StandardType` y `HTTPMethod` (enums sin payload usados por el `Request` `@unchecked Sendable` con métodos `@concurrent`). |

**Refactor de apoyo:** la composición de URL se extrajo a `Request+URLBuilding.swift` (siguiendo el patrón de `Request+Cancellation.swift`) para mantener `Request.swift` bajo el límite de 700 líneas de swiftlint. Esto requirió subir `RequestBuildError`, `logInvalidURLBuildError` y `concat` de `private` a `internal`.

## Tests
Cobertura nueva/ampliada: frontera 2xx (`199/200/204/299/300/301`), normalización del separador base/endpoint, `baseURL` sin esquema, codificación de query params por tipo y arrays incl. `0`/`1` bridgeados de ObjC y `NSNull`, supervivencia de una `URLSession` inyectada a `fetch()` repetidos (C060), y decodificación de GIF (válido → `images != nil`, inválido → throws).

## Verificación
- `swiftlint`: 0 warnings
- `xcodebuild -scheme GIGLibrary -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' test`: **155 tests OK**
- Build **Release**: sin warnings de StrictConcurrency

## Notas para el revisor
- ⚠️ **Cambio de API source-breaking**: `public private(set)` en las propiedades de `Response` (C065) rompería a cualquier consumidor externo que las mutara. Dentro del repo no hay ninguno; es el endurecimiento intencionado del hallazgo.
- **Seguimiento aparte**: tras C051, `Response.image()` decodifica GIFs animados, pero `ImageDownloader` los aplana a un frame estático al redimensionar (comportamiento preexistente, fuera del alcance de S1). Conviene decidir si `download(url:)` debe preservar la animación o documentar el uso de `loadGif`.
- C048 (endurecer `JSON` a tipo valor/Sendable) queda fuera; se aborda en otra sesión.

🤖 Generated with [Claude Code](https://claude.com/claude-code)