### PR TITLE
fix(ImageDownloader): hacer determinista el cacheo en tests para eliminar flake en CI

### DIFF
--- a/Sources/GIGLibrary/GIGUtils/Image/ImageDownloader.swift
+++ b/Sources/GIGLibrary/GIGUtils/Image/ImageDownloader.swift
@@ -36,6 +36,14 @@ struct ImageDownloader {
     static var fetchProvider: (_ request: Request) async -> Response = { request in
         await request.fetch()
     }
+
+    /// Seam used only by DEBUG builds: fired on the MainActor immediately after a successful
+    /// download's decode → resize step has written the image to `images`, carrying the cache key
+    /// (`request.baseURL`). It lets tests await that step deterministically instead of polling with
+    /// a timeout, so they cannot flake when the `.utility` resize task is scheduled late under CI
+    /// load — they wait for the real signal rather than racing a deadline. `nil` by default and
+    /// absent from release builds — see `handleResponse(_:view:request:)`.
+    static var didCacheImageForTesting: (@MainActor (_ cacheKey: String) -> Void)?
     #endif
 
     /// Backing store for `maxConcurrentDownloads`, always clamped to a minimum of 1.
@@ -191,6 +199,9 @@ struct ImageDownloader {
                     self.setAnimated(image: finalImage, in: view)
                     ImageDownloader.images[request.baseURL] = finalImage
                     ImageDownloader.queue.removeValue(forKey: view)
+                    #if DEBUG
+                    ImageDownloader.didCacheImageForTesting?(request.baseURL)
+                    #endif
                 }
             }
         default:

--- a/Tests/GIGLibraryTests/GIGUtils/ImageDownloaderTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/ImageDownloaderTests.swift
@@ -3,7 +3,7 @@ import UIKit
 @testable import GIGLibrary
 
 @MainActor
-@Suite(.serialized)
+@Suite(.serialized, .timeLimit(.minutes(1)))
 struct ImageDownloaderTests {
 
     // MARK: - Configuration
@@ -89,9 +89,11 @@ struct ImageDownloaderTests {
         #expect(ImageDownloader.activeDownloads == 1)
 
         // The slot is freed as soon as the (mocked) network finishes; the image is cached after the
-        // resize completes on the cooperative pool.
-        let cached = await waitUntil { ImageDownloader.images[urlString] != nil }
-        #expect(cached)
+        // resize completes on the cooperative pool. Await the cache write deterministically instead
+        // of polling: under CI load the `.utility` resize task can be scheduled late, which used to
+        // exhaust `waitUntil`'s deadline and flake. See `awaitCache`.
+        await awaitCache(of: urlString)
+        #expect(ImageDownloader.images[urlString] != nil)
         #expect(ImageDownloader.activeDownloads == 0)
     }
 
@@ -210,8 +212,8 @@ struct ImageDownloaderTests {
         let view = makeImageView()
         ImageDownloader.shared.download(url: urlString, for: view, placeholder: nil)
 
-        let cached = await waitUntil { ImageDownloader.images[urlString] != nil }
-        #expect(cached)
+        await awaitCache(of: urlString)
+        #expect(ImageDownloader.images[urlString] != nil)
         #expect(ImageDownloader.images[urlString]?.images != nil)
         #expect(ImageDownloader.activeDownloads == 0)
     }
@@ -262,6 +264,25 @@ struct ImageDownloaderTests {
         return makeImage(.red).pngData() ?? Data()
     }
 
+    /// Awaits the success-path cache write for `cacheKey` deterministically. `download(...)` is
+    /// fire-and-forget, so we install the DEBUG cache hook and suspend until the resize → cache step
+    /// fires it. Unlike `waitUntil`, this carries no deadline: when the `.utility` resize task is
+    /// scheduled late under CI load it simply waits for the real signal instead of racing a timeout
+    /// and flaking. The `.timeLimit` suite trait is the backstop against a genuine hang.
+    ///
+    /// Safe to install the hook here (rather than before `download`): the caller is `@MainActor`, so
+    /// the unstructured download `Task` and its detached resize cannot run until this function
+    /// suspends at the `await` below — the signal can never fire before the hook is in place.
+    private func awaitCache(of cacheKey: String) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            ImageDownloader.didCacheImageForTesting = { written in
+                guard written == cacheKey else { return }
+                ImageDownloader.didCacheImageForTesting = nil
+                continuation.resume()
+            }
+        }
+    }
+
     /// Polls `condition` on the MainActor until it is true or the timeout elapses. Returns as soon
     /// as the condition holds, so warm runs finish in milliseconds. The timeout is generous because
     /// the first test that chains async hops pays a one-time concurrency-runtime/simulator warm-up
@@ -290,6 +311,7 @@ extension ImageDownloader {
         maxConcurrentDownloads = 6  // setter clamps and pumps (a no-op while the stack is empty)
         requestProvider = { url in Request(method: .get, baseUrl: url, endpoint: "", bodyParams: nil) }
         fetchProvider = { request in await request.fetch() }
+        didCacheImageForTesting = nil
     }
 }
 


### PR DESCRIPTION
## Qué

Elimina la intermitencia (flake) de `ImageDownloaderTests.successReleasesSlotAndCaches()` y su gemelo `gifDownloadStaysAnimated()` en CI, reemplazando el polling con timeout por una espera determinista de la escritura en caché.

## Por qué

En runners `macos-latest` cargados, el camino de éxito de `ImageDownloader` cachea la imagen desde un `Task.detached(priority: .utility)`. Con el pool cooperativo saturado (suites que Swift Testing corre en paralelo + QoS reducido del proceso), esa tarea `.utility` se planificaba tan tarde que el `waitUntil` de 30 s **agotaba su deadline antes de que el cacheo aterrizara** y el test fallaba en `#expect(cached)` (la suite tardó ~88 s en CI vs ~1 s en local). El slot ya se liberaba bien (`activeDownloads == 1` pasaba); solo el cacheo post-completion no llegaba a tiempo.

## Cómo

- **Espera determinista en vez de polling con deadline.** Los dos tests de cacheo ahora hacen `await awaitCache(of:)`, que suspende en un `CheckedContinuation` hasta la señal real de escritura en caché. Si la tarea `.utility` va lenta, el test **espera lo correcto** en lugar de competir contra un reloj, por lo que no puede dar un falso fallo.
- **Hook solo-`#if DEBUG`** (`didCacheImageForTesting`), junto a los seams `fetchProvider`/`requestProvider` ya existentes. Se dispara en el MainActor justo tras escribir en `images`, dentro del guard de identidad de request.
- **`.timeLimit(.minutes(1))`** en la suite como red de seguridad ante un cuelgue real (en vez de quedar colgada indefinidamente).
- Reset del hook en `resetForTesting()`.

Instalar el hook tras `download(...)` es seguro: el test es `@MainActor`, así que la `Task` no estructurada de descarga y su resize detached no corren hasta que la función suspende en el `await` — la señal nunca puede dispararse antes de que el hook esté puesto.

## Notas para revisión

- **Producción sin cambios de comportamiento.** El hook es `#if DEBUG`, `nil` por defecto y **ausente en builds Release** — verificado con build Release sin warnings nuevos de concurrencia. Cumple la regla de no meter código de test en `Sources/` (queda tras `#if DEBUG`).
- Aislamiento de concurrencia correcto: `static var` sobre tipo `@MainActor` con closure `@MainActor`; todo acceso es serial en el MainActor, sin data races ni `Sendable`/locks.

## Validación

- ✅ Suite completa (`xcodebuild`, iPhone 17 Pro): `TEST SUCCEEDED`
- ✅ SwiftLint: 0 violaciones en 64 archivos
- ✅ Build Release: `BUILD SUCCEEDED`, sin warnings de concurrencia

🤖 Generated with [Claude Code](https://claude.com/claude-code)