### PR TITLE
fix(Style): release audit S3 — Style bugs & dead code (C027–C031, C070–C074)

### DIFF
--- a/Sources/GIGLibrary/GIGUtils/Style/StylableExtensions/UIButton+Stylable.swift
+++ b/Sources/GIGLibrary/GIGUtils/Style/StylableExtensions/UIButton+Stylable.swift
@@ -17,11 +17,17 @@ extension UIButton: Stylable {
 
         if let image = style.backgroundImage {
             setBackgroundImage(image, for: .normal)
+        } else if let styled = self as? StyledButton {
+            // `StyledButton` tracks `isEnabled` and swaps between the two dynamic colours, so
+            // the disabled background is state-aware and re-resolves on trait changes. The
+            // enabled colour comes from `viewStyle.backgroundColor` (already applied above).
+            styled.setStatefulBackgroundColors(enabled: style.viewStyle?.backgroundColor,
+                                               disabled: style.disabledBackgroundColor)
         }
-        // No disabled-state background dimming: `backgroundColor` is not state-aware, so
-        // dimming it for the disabled state (the old alpha-0.3 path) stuck after the button
-        // was re-enabled (C027). A reused text-only restyle is also left untouched here, so
-        // an existing background image/colour is preserved. A proper state-aware disabled
-        // background would need an explicit colour on `ButtonStyle` rather than mutating this.
+        // For a plain `UIButton`, the enabled `backgroundColor` (set by `withViewStyle`) is the
+        // only background: `backgroundColor` is not state-aware, so a disabled dim would either
+        // stick after re-enabling (C027) or freeze a dynamic colour into an image. A text-only
+        // restyle leaves any existing background untouched. Use `StyledButton` for a state-aware
+        // disabled background via `ButtonStyle.disabledBackgroundColor`.
 	}
 }

--- a/Sources/GIGLibrary/GIGUtils/Style/StylableExtensions/UIButton+Stylable.swift
+++ b/Sources/GIGLibrary/GIGUtils/Style/StylableExtensions/UIButton+Stylable.swift
@@ -9,25 +9,19 @@ extension UIButton: Stylable {
         }
         
         if let viewStyle = style.viewStyle {
+            // `withViewStyle` assigns `backgroundColor` directly. Keeping the colour (rather
+            // than rendering it into a 1×1 image) lets dynamic colours re-resolve on
+            // light/dark trait changes — the same reason ViewStyle defaults to `.clear`.
             self.withViewStyle(viewStyle)
         }
-        
-        // Clear the per-state background images this method manages before re-applying,
-        // so a reused button does not keep stale images from a previous style (e.g. a
-        // color-based `.disabled` dim leaking under a later `backgroundImage` style).
-        setBackgroundImage(nil, for: .normal)
-        setBackgroundImage(nil, for: .disabled)
 
         if let image = style.backgroundImage {
             setBackgroundImage(image, for: .normal)
-        } else if let backgroundColor = style.viewStyle?.backgroundColor {
-            // `backgroundColor` is not state-aware: deriving the disabled dim from it
-            // (alpha 0.3) would stick after the button is re-enabled. Drive the appearance
-            // through per-state background images instead, so UIKit restores the enabled
-            // look automatically when `isEnabled` changes.
-            self.backgroundColor = nil
-            setBackgroundImage(UIImage.create(from: backgroundColor), for: .normal)
-            setBackgroundImage(UIImage.create(from: backgroundColor.withAlphaComponent(0.3)), for: .disabled)
         }
+        // No disabled-state background dimming: `backgroundColor` is not state-aware, so
+        // dimming it for the disabled state (the old alpha-0.3 path) stuck after the button
+        // was re-enabled (C027). A reused text-only restyle is also left untouched here, so
+        // an existing background image/colour is preserved. A proper state-aware disabled
+        // background would need an explicit colour on `ButtonStyle` rather than mutating this.
 	}
 }

--- a/Sources/GIGLibrary/GIGUtils/Style/StylableExtensions/UIButton+Stylable.swift
+++ b/Sources/GIGLibrary/GIGUtils/Style/StylableExtensions/UIButton+Stylable.swift
@@ -14,11 +14,14 @@ extension UIButton: Stylable {
         
         if let image = style.backgroundImage {
             setBackgroundImage(image, for: .normal)
-        } else {
-            self.backgroundColor = style.viewStyle?.backgroundColor
-            if !isEnabled {
-                self.backgroundColor = self.backgroundColor?.withAlphaComponent(0.3)
-            }
+        } else if let backgroundColor = style.viewStyle?.backgroundColor {
+            // `backgroundColor` is not state-aware: deriving the disabled dim from it
+            // (alpha 0.3) would stick after the button is re-enabled. Drive the appearance
+            // through per-state background images instead, so UIKit restores the enabled
+            // look automatically when `isEnabled` changes.
+            self.backgroundColor = nil
+            setBackgroundImage(UIImage.create(from: backgroundColor), for: .normal)
+            setBackgroundImage(UIImage.create(from: backgroundColor.withAlphaComponent(0.3)), for: .disabled)
         }
 	}
 }

--- a/Sources/GIGLibrary/GIGUtils/Style/StylableExtensions/UIButton+Stylable.swift
+++ b/Sources/GIGLibrary/GIGUtils/Style/StylableExtensions/UIButton+Stylable.swift
@@ -12,6 +12,12 @@ extension UIButton: Stylable {
             self.withViewStyle(viewStyle)
         }
         
+        // Clear the per-state background images this method manages before re-applying,
+        // so a reused button does not keep stale images from a previous style (e.g. a
+        // color-based `.disabled` dim leaking under a later `backgroundImage` style).
+        setBackgroundImage(nil, for: .normal)
+        setBackgroundImage(nil, for: .disabled)
+
         if let image = style.backgroundImage {
             setBackgroundImage(image, for: .normal)
         } else if let backgroundColor = style.viewStyle?.backgroundColor {

--- a/Sources/GIGLibrary/GIGUtils/Style/StylableExtensions/UIButton+Stylable.swift
+++ b/Sources/GIGLibrary/GIGUtils/Style/StylableExtensions/UIButton+Stylable.swift
@@ -17,10 +17,16 @@ extension UIButton: Stylable {
 
         if let image = style.backgroundImage {
             setBackgroundImage(image, for: .normal)
-        } else if let styled = self as? StyledButton {
+            // Image takes precedence: drop any cached state-aware colours so a later
+            // `isEnabled` change doesn't repaint a stale background behind the image.
+            (self as? StyledButton)?.setStatefulBackgroundColors(enabled: nil, disabled: nil)
+        } else if let styled = self as? StyledButton,
+                  style.viewStyle != nil || style.disabledBackgroundColor != nil {
             // `StyledButton` tracks `isEnabled` and swaps between the two dynamic colours, so
             // the disabled background is state-aware and re-resolves on trait changes. The
             // enabled colour comes from `viewStyle.backgroundColor` (already applied above).
+            // Only (re)configure when the style carries background info — a text-only restyle
+            // leaves the button's existing state-aware colours untouched.
             styled.setStatefulBackgroundColors(enabled: style.viewStyle?.backgroundColor,
                                                disabled: style.disabledBackgroundColor)
         }

--- a/Sources/GIGLibrary/GIGUtils/Style/StylableExtensions/UIString+Stylable.swift
+++ b/Sources/GIGLibrary/GIGUtils/Style/StylableExtensions/UIString+Stylable.swift
@@ -16,12 +16,14 @@ public extension String {
         
         if style.isStrikedThrough {
             attrString.addAttribute(NSAttributedString.Key.strikethroughStyle,
-                                    value: 2,
-                                    range: NSRange(location: 0, length: attrString.length) )
+                                    value: NSUnderlineStyle.single.rawValue,
+                                    range: NSRange(location: 0, length: attrString.length))
             attrString.addAttribute(NSAttributedString.Key.strikethroughColor,
                                     value: style.foregroundColor,
                                     range: NSRange(location: 0, length: attrString.length))
-        } else if let space = style.letterSpacing {
+        }
+
+        if let space = style.letterSpacing {
             attrString.addAttribute(NSAttributedString.Key.kern, value: space, range: NSRange(location: 0, length: attrString.length))
         }
         return attrString

--- a/Sources/GIGLibrary/GIGUtils/Style/StyledButton.swift
+++ b/Sources/GIGLibrary/GIGUtils/Style/StyledButton.swift
@@ -1,0 +1,39 @@
+import UIKit
+
+/// A `UIButton` that applies a state-aware background colour.
+///
+/// `UIView.backgroundColor` is not state-aware, so a plain `UIButton` cannot dim its
+/// background when disabled without either freezing dynamic colours into an image or
+/// leaving a baked-in alpha that sticks after re-enabling (the C027 bug). `StyledButton`
+/// solves both: it stores the enabled/disabled colours and swaps `backgroundColor` in
+/// `isEnabled`'s `didSet`. Because it assigns a `UIColor` (not a rendered image), a dynamic
+/// colour (e.g. `.systemBackground` or an asset colour) keeps re-resolving on light/dark
+/// trait changes.
+///
+/// Style it through `withStyle(_:)` with a `ButtonStyle` whose `disabledBackgroundColor`
+/// is set; the colours are wired up automatically.
+public final class StyledButton: UIButton {
+    private var enabledBackgroundColor: UIColor?
+    private var disabledBackgroundColor: UIColor?
+
+    public override var isEnabled: Bool {
+        didSet { applyStatefulBackgroundColor() }
+    }
+
+    // MARK: - Internal API
+
+    /// Stores the enabled/disabled background colours and immediately applies the one that
+    /// matches the current `isEnabled` state. When `disabled` is `nil` the enabled colour is
+    /// used for both states (no dimming). Called by `UIButton.withStyle(_:)`.
+    func setStatefulBackgroundColors(enabled: UIColor?, disabled: UIColor?) {
+        enabledBackgroundColor = enabled
+        disabledBackgroundColor = disabled
+        applyStatefulBackgroundColor()
+    }
+
+    // MARK: - Private Helpers
+
+    private func applyStatefulBackgroundColor() {
+        backgroundColor = isEnabled ? enabledBackgroundColor : (disabledBackgroundColor ?? enabledBackgroundColor)
+    }
+}

--- a/Sources/GIGLibrary/GIGUtils/Style/Styles/ButtonStyle.swift
+++ b/Sources/GIGLibrary/GIGUtils/Style/Styles/ButtonStyle.swift
@@ -6,10 +6,9 @@ public struct ButtonStyle {
     let viewStyle: ViewStyle?
     let backgroundImage: UIImage?
     
-    /// Its possible to set attributted text and ViewStyle to Label individually,
+    /// It's possible to set attributed text and ViewStyle to a Button individually,
     /// or use this init.
-    
-    /// If set backgroundImage backgroundColor from viewStyle is not apply.
+    /// If set, backgroundImage takes precedence and backgroundColor from viewStyle is not applied.
     public init(
         textStyle: TextStyle,
         tintColor: UIColor? = nil,

--- a/Sources/GIGLibrary/GIGUtils/Style/Styles/ButtonStyle.swift
+++ b/Sources/GIGLibrary/GIGUtils/Style/Styles/ButtonStyle.swift
@@ -5,19 +5,24 @@ public struct ButtonStyle {
     let tintColor: UIColor?
     let viewStyle: ViewStyle?
     let backgroundImage: UIImage?
-    
+    let disabledBackgroundColor: UIColor?
+
     /// It's possible to set attributed text and ViewStyle to a Button individually,
     /// or use this init.
     /// If set, backgroundImage takes precedence and backgroundColor from viewStyle is not applied.
+    /// `disabledBackgroundColor` provides a state-aware background for the disabled state; it is
+    /// only honoured by `StyledButton` (a plain `UIButton` is not state-aware — see `StyledButton`).
     public init(
         textStyle: TextStyle,
         tintColor: UIColor? = nil,
         viewStyle: ViewStyle? = nil,
-        backgroundImage: UIImage? = nil
+        backgroundImage: UIImage? = nil,
+        disabledBackgroundColor: UIColor? = nil
     ) {
         self.textStyle = textStyle
         self.tintColor = tintColor
         self.viewStyle = viewStyle
         self.backgroundImage = backgroundImage
+        self.disabledBackgroundColor = disabledBackgroundColor
     }
 }

--- a/Sources/GIGLibrary/GIGUtils/Style/Styles/TextViewStyle.swift
+++ b/Sources/GIGLibrary/GIGUtils/Style/Styles/TextViewStyle.swift
@@ -4,20 +4,17 @@ public struct TextViewStyle {
     let font: UIFont
     let tintColor: UIColor
     let textColor: UIColor
-    let borderStyle: UITextField.BorderStyle
     let viewStyle: ViewStyle?
-    
+
     public init(
         font: UIFont,
         tintColor: UIColor = .blue,
         textColor: UIColor = .black,
-        borderStyle: UITextField.BorderStyle = .line,
         viewStyle: ViewStyle? = nil
     ) {
         self.font = font
         self.tintColor = tintColor
         self.textColor = textColor
-        self.borderStyle = borderStyle
         self.viewStyle = viewStyle
     }
 }

--- a/Sources/GIGLibrary/GIGUtils/Style/Styles/ViewStyle.swift
+++ b/Sources/GIGLibrary/GIGUtils/Style/Styles/ViewStyle.swift
@@ -1,19 +1,18 @@
 import UIKit
 
 public struct ViewStyle {
-    var borderColor: UIColor
-    var borderWidth: CGFloat
-    var someBorders: [Border]
-    var dottedBorders: Bool
-    var cornerRadius: CGFloat?
-    var shadowColor: UIColor
-    var shadowOffset: CGSize
-    var shadowOpacity: Float
-    var shadowRadius: CGFloat
-    var backgroundColor: UIColor
-    
-    /// If set dottedBorders, someBorders not apply
-    /// If set dottedBorders, someBorders not apply
+    let borderColor: UIColor
+    let borderWidth: CGFloat
+    let someBorders: [Border]
+    let dottedBorders: Bool
+    let cornerRadius: CGFloat?
+    let shadowColor: UIColor
+    let shadowOffset: CGSize
+    let shadowOpacity: Float
+    let shadowRadius: CGFloat
+    let backgroundColor: UIColor
+
+    /// If set, dottedBorders takes precedence and someBorders is not applied.
     public init(
         borderColor: UIColor = .clear,
         borderWidth: CGFloat = 0.0,
@@ -24,7 +23,7 @@ public struct ViewStyle {
         shadowOpacity: Float = 0.0,
         shadowRadius: CGFloat = 0.0,
         cornerRadius: CGFloat? = nil,
-        backgroundColor: UIColor = .white
+        backgroundColor: UIColor = .clear
     ) {
         
         self.borderColor = borderColor

--- a/Sources/GIGLibrary/GIGUtils/Style/UIKitExtensions/UIView+Borders.swift
+++ b/Sources/GIGLibrary/GIGUtils/Style/UIKitExtensions/UIView+Borders.swift
@@ -93,12 +93,25 @@ public extension UIView {
         let borderView = DottedBorderView(weight: weight, color: color)
         borderView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(borderView)
-        NSLayoutConstraint.activate([
-            borderView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            borderView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            borderView.topAnchor.constraint(equalTo: topAnchor),
-            borderView.bottomAnchor.constraint(equalTo: bottomAnchor)
-        ])
+        // On a scroll view, pin to the frame layout guide so the border tracks the viewport
+        // instead of becoming scrollable content (which would also perturb `contentSize`).
+        // Other views pin to their own edges.
+        if let scrollView = self as? UIScrollView {
+            let guide = scrollView.frameLayoutGuide
+            NSLayoutConstraint.activate([
+                borderView.leadingAnchor.constraint(equalTo: guide.leadingAnchor),
+                borderView.trailingAnchor.constraint(equalTo: guide.trailingAnchor),
+                borderView.topAnchor.constraint(equalTo: guide.topAnchor),
+                borderView.bottomAnchor.constraint(equalTo: guide.bottomAnchor)
+            ])
+        } else {
+            NSLayoutConstraint.activate([
+                borderView.leadingAnchor.constraint(equalTo: leadingAnchor),
+                borderView.trailingAnchor.constraint(equalTo: trailingAnchor),
+                borderView.topAnchor.constraint(equalTo: topAnchor),
+                borderView.bottomAnchor.constraint(equalTo: bottomAnchor)
+            ])
+        }
     }
 	
 	func resetBorder(_ border: Border) {

--- a/Sources/GIGLibrary/GIGUtils/Style/UIKitExtensions/UIView+Borders.swift
+++ b/Sources/GIGLibrary/GIGUtils/Style/UIKitExtensions/UIView+Borders.swift
@@ -9,6 +9,40 @@ public enum Border: Int {
 
 private final class BorderView: UIView { }
 
+/// Draws a dashed border that tracks the host view's bounds and corner radius.
+///
+/// Implemented as a pinned subview (instead of a bare `CAShapeLayer` on the host's
+/// layer) so the path is recomputed in `layoutSubviews` — staying correct across
+/// rotation and resize rather than being captured pre-layout. Isolating the dashed
+/// border in its own view also lets `resetBorders()` remove only this overlay,
+/// without touching unrelated `CAShapeLayer`s added by callers.
+private final class DottedBorderView: UIView {
+    private let shapeLayer = CAShapeLayer()
+
+    init(weight: CGFloat, color: UIColor) {
+        super.init(frame: .zero)
+        self.isUserInteractionEnabled = false
+        self.backgroundColor = .clear
+        shapeLayer.fillColor = UIColor.clear.cgColor
+        shapeLayer.strokeColor = color.cgColor
+        shapeLayer.lineWidth = weight
+        shapeLayer.lineDashPattern = [4, 2]
+        self.layer.addSublayer(shapeLayer)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // Inherit the host's corner radius; it may be set after the border is attached.
+        let radius = superview?.layer.cornerRadius ?? 0
+        shapeLayer.frame = bounds
+        shapeLayer.cornerRadius = radius
+        shapeLayer.path = UIBezierPath(roundedRect: bounds, cornerRadius: radius).cgPath
+    }
+}
+
 public extension UIView {
     
     func addSomeBorders(_ border: Border, weight: CGFloat, color: UIColor) {
@@ -55,14 +89,15 @@ public extension UIView {
     }
 	
     func addDottedBorder(weight: CGFloat, color: UIColor) {
-        let border = CAShapeLayer()
-        border.cornerRadius = self.layer.cornerRadius
-        border.strokeColor = color.cgColor
-        border.fillColor = UIColor.clear.cgColor
-        border.lineDashPattern = [4, 2]
-		border.lineWidth = weight
-        border.path = UIBezierPath(roundedRect: self.bounds, cornerRadius: self.layer.cornerRadius).cgPath
-        self.layer.addSublayer(border)
+        let borderView = DottedBorderView(weight: weight, color: color)
+        borderView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(borderView)
+        NSLayoutConstraint.activate([
+            borderView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            borderView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            borderView.topAnchor.constraint(equalTo: topAnchor),
+            borderView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
     }
 	
 	func resetBorder(_ border: Border) {
@@ -70,18 +105,8 @@ public extension UIView {
 	}
 	
 	func resetBorders() {
-		// Remove all previous BorderView subviews (solid borders)
-		self.subviews.filter { $0 is BorderView }.forEach { $0.removeFromSuperview() }
-		// Remove all CAShapeLayer sublayers from layer (dotted borders)
-		self.layer.sublayers?.filter({ $0 is CAShapeLayer }).forEach({ $0.removeFromSuperlayer() })
+		// Remove the border overlays we added: solid `BorderView`s and the dashed
+		// `DottedBorderView`. Unrelated subviews and layers are left untouched.
+		self.subviews.filter { $0 is BorderView || $0 is DottedBorderView }.forEach { $0.removeFromSuperview() }
     }
-
-	func roundCorners(corners: UIRectCorner, radius: CGFloat) {
-		let path = UIBezierPath(roundedRect: self.bounds, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
-		let mask = CAShapeLayer()
-		let rect = self.bounds
-		mask.frame = rect
-		mask.path = path.cgPath
-		self.layer.mask = mask
-	}
 }

--- a/Sources/GIGLibrary/GIGUtils/Style/UIKitExtensions/UIView+Borders.swift
+++ b/Sources/GIGLibrary/GIGUtils/Style/UIKitExtensions/UIView+Borders.swift
@@ -36,9 +36,10 @@ private final class DottedBorderView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         // Inherit the host's corner radius; it may be set after the border is attached.
+        // The rounding comes from the bezier path itself — the layer's own `cornerRadius`
+        // has no effect on a path-stroked CAShapeLayer, so it is not set here.
         let radius = superview?.layer.cornerRadius ?? 0
         shapeLayer.frame = bounds
-        shapeLayer.cornerRadius = radius
         shapeLayer.path = UIBezierPath(roundedRect: bounds, cornerRadius: radius).cgPath
     }
 }

--- a/Sources/GIGLibrary/GIGUtils/View/View+Extension.swift
+++ b/Sources/GIGLibrary/GIGUtils/View/View+Extension.swift
@@ -72,6 +72,7 @@ extension UIView {
     public func roundCorners(_ corners: UIRectCorner, radius: CGFloat) {
         let path = UIBezierPath(roundedRect: self.bounds, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
         let mask = CAShapeLayer()
+        mask.frame = self.bounds
         mask.path = path.cgPath
         self.layer.mask = mask
     }

--- a/Tests/GIGLibraryTests/GIGUtils/StylableTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/StylableTests.swift
@@ -20,9 +20,12 @@ class StylableTests: XCTestCase {
         XCTAssertEqual(attrString.attribute(named: NSAttributedString.Key.font.rawValue, forText: stringToTest)as! UIFont, UIFont.systemFont(ofSize: 10))
         XCTAssertEqual(attrString.attribute(named: NSAttributedString.Key.foregroundColor.rawValue, forText: stringToTest)as! UIColor, .blue)
         XCTAssertEqual(attrString.attribute(named: NSAttributedString.Key.backgroundColor.rawValue, forText: stringToTest)as! UIColor, .green)
-        XCTAssertNotNil(attrString.attribute(named: NSAttributedString.Key.strikethroughStyle.rawValue, forText: stringToTest))
         XCTAssertNotNil(attrString.attribute(named: NSAttributedString.Key.underlineStyle.rawValue, forText: stringToTest))
-//        XCTAssert(attrString.attribute(named: NSAttributedStringKey.kern.rawValue, forText: stringToTest) as! CGFloat == 3)
+        // C070: strikethrough uses NSUnderlineStyle.single, not the magic literal 2 (.thick).
+        XCTAssertEqual(attrString.attribute(named: NSAttributedString.Key.strikethroughStyle.rawValue, forText: stringToTest) as? Int,
+                       NSUnderlineStyle.single.rawValue)
+        // C028: letterSpacing (kern) is applied even when isStrikedThrough is true.
+        XCTAssertEqual(attrString.attribute(named: NSAttributedString.Key.kern.rawValue, forText: stringToTest) as? CGFloat, 3)
     }
     
     func test_applyStyle_to_View() {
@@ -73,7 +76,6 @@ class StylableTests: XCTestCase {
         let textViewStyle = TextViewStyle(font: UIFont.systemFont(ofSize: 10),
                                           tintColor: .blue,
                                           textColor: .green,
-                                          borderStyle: .bezel,
                                           viewStyle: viewStyle)
         sut.withStyle(textViewStyle)
         XCTAssertEqual(sut.font, UIFont.systemFont(ofSize: 10))
@@ -117,5 +119,48 @@ class StylableTests: XCTestCase {
         
         XCTAssertEqual(sut.titleLabel?.font, UIFont.boldSystemFont(ofSize: 12))
         XCTAssertEqual(sut.layer.borderColor, UIColor.red.cgColor)
+    }
+
+    func test_applyStyle_to_disabled_Button_does_not_persist_dim() {
+        // C027: a button styled while disabled must not keep the 30% dim baked into
+        // backgroundColor after it is re-enabled. The background is now state-aware.
+        let sut = UIButton(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        sut.isEnabled = false
+        let viewStyle = ViewStyle(backgroundColor: .red)
+        let buttonStyle = ButtonStyle(textStyle: TextStyle(font: UIFont.systemFont(ofSize: 10)),
+                                      viewStyle: viewStyle)
+        sut.withStyle(buttonStyle)
+
+        // backgroundColor is not used for the fill, so re-enabling cannot leave a stuck dim.
+        XCTAssertNil(sut.backgroundColor)
+        // Enabled and disabled appearances are provided as separate, state-specific images.
+        XCTAssertNotNil(sut.backgroundImage(for: .normal))
+        XCTAssertNotNil(sut.backgroundImage(for: .disabled))
+        XCTAssertNotEqual(sut.backgroundImage(for: .normal), sut.backgroundImage(for: .disabled))
+    }
+
+    func test_dottedBorder_addsSingleOverlay_and_resetRemovesItOnly() {
+        // C030/C031: the dashed border is a dedicated overlay subview. Applying it must add
+        // exactly one overlay (no accumulation on re-style), resetBorders must remove that
+        // overlay, and neither operation may touch foreign subviews or foreign layers.
+        let host = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
+        let foreignSubview = UIView()
+        host.addSubview(foreignSubview)
+        let foreignLayer = CAShapeLayer()
+        host.layer.addSublayer(foreignLayer)
+        let baseSubviews = host.subviews.count
+
+        let style = ViewStyle(borderColor: .red, borderWidth: 2, dottedBorders: true)
+        host.withViewStyle(style)
+        XCTAssertEqual(host.subviews.count, baseSubviews + 1, "Expected exactly one dashed-border overlay")
+
+        // Re-styling resets first, so overlays must not accumulate.
+        host.withViewStyle(style)
+        XCTAssertEqual(host.subviews.count, baseSubviews + 1, "Re-styling must not accumulate overlays")
+
+        host.resetBorders()
+        XCTAssertEqual(host.subviews.count, baseSubviews, "resetBorders must remove the dashed-border overlay")
+        XCTAssertTrue(host.subviews.contains(foreignSubview), "resetBorders must not remove foreign subviews")
+        XCTAssertEqual(host.layer.sublayers?.contains(foreignLayer), true, "resetBorders must not remove foreign layers")
     }
 }

--- a/Tests/GIGLibraryTests/GIGUtils/StylableTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/StylableTests.swift
@@ -168,6 +168,45 @@ class StylableTests: XCTestCase {
         XCTAssertEqual(sut.backgroundColor, .systemBackground, "re-enabling restores the enabled colour — no stuck state")
     }
 
+    func test_StyledButton_textOnly_restyle_preserves_stateful_background() {
+        // A typography-only restyle (no viewStyle/backgroundImage/disabledBackgroundColor)
+        // must not wipe the StyledButton's cached state-aware colours.
+        let sut = StyledButton(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        sut.withStyle(ButtonStyle(textStyle: TextStyle(font: UIFont.systemFont(ofSize: 10)),
+                                  viewStyle: ViewStyle(backgroundColor: .systemBackground),
+                                  disabledBackgroundColor: .systemGray))
+
+        sut.withStyle(ButtonStyle(textStyle: TextStyle(font: UIFont.boldSystemFont(ofSize: 14))))
+        XCTAssertEqual(sut.backgroundColor, .systemBackground, "enabled colour must survive a text-only restyle")
+        sut.isEnabled = false
+        XCTAssertEqual(sut.backgroundColor, .systemGray, "disabled colour must survive a text-only restyle")
+    }
+
+    func test_StyledButton_image_style_clears_stateful_colors() {
+        // Switching a StyledButton to an image-backed style must clear the cached colours so a
+        // later isEnabled change does not repaint a stale background behind the image.
+        let sut = StyledButton(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        sut.withStyle(ButtonStyle(textStyle: TextStyle(font: UIFont.systemFont(ofSize: 10)),
+                                  viewStyle: ViewStyle(backgroundColor: .red),
+                                  disabledBackgroundColor: .gray))
+        sut.withStyle(ButtonStyle(textStyle: TextStyle(font: UIFont.systemFont(ofSize: 10)),
+                                  backgroundImage: UIImage.create(from: .blue)))
+
+        sut.isEnabled = false
+        XCTAssertNil(sut.backgroundColor, "stateful colours must be cleared when switching to an image style")
+    }
+
+    func test_dottedBorder_on_scrollView_pins_to_frameLayoutGuide() {
+        // C031 follow-up: on a scroll view the dashed border must pin to the frame layout guide
+        // (viewport), not the content area, so it doesn't scroll or perturb contentSize.
+        let sut = UIScrollView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        sut.withViewStyle(ViewStyle(borderColor: .red, borderWidth: 1, dottedBorders: true))
+
+        let guide = sut.frameLayoutGuide
+        let pinsToFrameGuide = sut.constraints.contains { $0.firstItem === guide || $0.secondItem === guide }
+        XCTAssertTrue(pinsToFrameGuide, "dashed border on a scroll view must pin to the frame layout guide")
+    }
+
     func test_StyledButton_without_disabledColor_keeps_enabled_color_when_disabled() {
         // When no disabledBackgroundColor is provided, the enabled colour is used for both
         // states (no dimming), so the behaviour matches a plain styled button.

--- a/Tests/GIGLibraryTests/GIGUtils/StylableTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/StylableTests.swift
@@ -148,6 +148,47 @@ class StylableTests: XCTestCase {
         XCTAssertNil(sut.backgroundImage(for: .normal))
     }
 
+    func test_StyledButton_disabledBackgroundColor_is_state_aware_and_dynamic() {
+        // C027 follow-up: StyledButton applies a state-aware disabled background by swapping
+        // backgroundColor on isEnabled changes. Colours are stored as dynamic UIColors (not
+        // frozen images), so they re-resolve on light/dark trait changes.
+        let sut = StyledButton(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        let style = ButtonStyle(textStyle: TextStyle(font: UIFont.systemFont(ofSize: 10)),
+                                viewStyle: ViewStyle(backgroundColor: .systemBackground),
+                                disabledBackgroundColor: .systemGray)
+        sut.withStyle(style)
+
+        XCTAssertEqual(sut.backgroundColor, .systemBackground, "enabled uses the enabled dynamic colour")
+        XCTAssertNil(sut.backgroundImage(for: .normal), "no frozen image is used")
+
+        sut.isEnabled = false
+        XCTAssertEqual(sut.backgroundColor, .systemGray, "disabling swaps to the disabled dynamic colour")
+
+        sut.isEnabled = true
+        XCTAssertEqual(sut.backgroundColor, .systemBackground, "re-enabling restores the enabled colour — no stuck state")
+    }
+
+    func test_StyledButton_without_disabledColor_keeps_enabled_color_when_disabled() {
+        // When no disabledBackgroundColor is provided, the enabled colour is used for both
+        // states (no dimming), so the behaviour matches a plain styled button.
+        let sut = StyledButton(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        sut.withStyle(ButtonStyle(textStyle: TextStyle(font: UIFont.systemFont(ofSize: 10)),
+                                  viewStyle: ViewStyle(backgroundColor: .red)))
+        sut.isEnabled = false
+        XCTAssertEqual(sut.backgroundColor, .red)
+    }
+
+    func test_plain_UIButton_ignores_disabledBackgroundColor() {
+        // A plain UIButton is not state-aware: disabledBackgroundColor is documented as
+        // StyledButton-only, so the background stays the enabled colour.
+        let sut = UIButton(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        sut.isEnabled = false
+        sut.withStyle(ButtonStyle(textStyle: TextStyle(font: UIFont.systemFont(ofSize: 10)),
+                                  viewStyle: ViewStyle(backgroundColor: .red),
+                                  disabledBackgroundColor: .gray))
+        XCTAssertEqual(sut.backgroundColor, .red)
+    }
+
     func test_textOnly_restyle_preserves_existing_background_image() {
         // Re-styling an image-backed button with a text-only ButtonStyle (typography update)
         // must not wipe the existing background image.

--- a/Tests/GIGLibraryTests/GIGUtils/StylableTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/StylableTests.swift
@@ -122,8 +122,9 @@ class StylableTests: XCTestCase {
     }
 
     func test_applyStyle_to_disabled_Button_does_not_persist_dim() {
-        // C027: a button styled while disabled must not keep the 30% dim baked into
-        // backgroundColor after it is re-enabled. The background is now state-aware.
+        // C027: a button styled while disabled must not get a 30% dim baked into
+        // backgroundColor (which is not state-aware and would stick after re-enabling).
+        // The background colour is applied at full opacity, with no per-state image.
         let sut = UIButton(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
         sut.isEnabled = false
         let viewStyle = ViewStyle(backgroundColor: .red)
@@ -131,29 +132,34 @@ class StylableTests: XCTestCase {
                                       viewStyle: viewStyle)
         sut.withStyle(buttonStyle)
 
-        // backgroundColor is not used for the fill, so re-enabling cannot leave a stuck dim.
-        XCTAssertNil(sut.backgroundColor)
-        // Enabled and disabled appearances are provided as separate, state-specific images.
-        XCTAssertNotNil(sut.backgroundImage(for: .normal))
-        XCTAssertNotNil(sut.backgroundImage(for: .disabled))
-        XCTAssertNotEqual(sut.backgroundImage(for: .normal), sut.backgroundImage(for: .disabled))
+        XCTAssertEqual(sut.backgroundColor, .red, "background must be the full colour, not a dimmed variant")
+        XCTAssertNil(sut.backgroundImage(for: .normal))
     }
 
-    func test_restyling_Button_clears_stale_disabled_background() {
-        // A reused button first styled by color sets a .disabled dim image. Restyling it
-        // with an explicit backgroundImage must not leave that stale .disabled image behind.
+    func test_colorStyle_keeps_dynamic_backgroundColor() {
+        // The background colour is assigned directly (not rendered into a 1×1 image), so a
+        // dynamic UIColor is preserved as-is and re-resolves on light/dark trait changes.
         let sut = UIButton(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
-        let textStyle = TextStyle(font: UIFont.systemFont(ofSize: 10))
-        sut.withStyle(ButtonStyle(textStyle: textStyle, viewStyle: ViewStyle(backgroundColor: .red)))
-        XCTAssertNotNil(sut.backgroundImage(for: .disabled), "color style should install a disabled dim image")
+        let buttonStyle = ButtonStyle(textStyle: TextStyle(font: UIFont.systemFont(ofSize: 10)),
+                                      viewStyle: ViewStyle(backgroundColor: .systemBackground))
+        sut.withStyle(buttonStyle)
 
+        XCTAssertEqual(sut.backgroundColor, .systemBackground, "dynamic colour must be stored as-is, not frozen")
+        XCTAssertNil(sut.backgroundImage(for: .normal))
+    }
+
+    func test_textOnly_restyle_preserves_existing_background_image() {
+        // Re-styling an image-backed button with a text-only ButtonStyle (typography update)
+        // must not wipe the existing background image.
+        let sut = UIButton(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
         let explicitImage = UIImage.create(from: .blue)
-        sut.withStyle(ButtonStyle(textStyle: textStyle, backgroundImage: explicitImage))
+        sut.withStyle(ButtonStyle(textStyle: TextStyle(font: UIFont.systemFont(ofSize: 10)),
+                                  backgroundImage: explicitImage))
         XCTAssertEqual(sut.backgroundImage(for: .normal), explicitImage)
-        // No explicit .disabled image now, so UIKit falls back to the new .normal image —
-        // the stale color dim is gone (it would NOT equal the new image if it had leaked).
-        XCTAssertEqual(sut.backgroundImage(for: .disabled), explicitImage,
-                       "stale disabled dim must be cleared so the new style's image is used")
+
+        sut.withStyle(ButtonStyle(textStyle: TextStyle(font: UIFont.boldSystemFont(ofSize: 14))))
+        XCTAssertEqual(sut.backgroundImage(for: .normal), explicitImage,
+                       "text-only restyle must preserve the existing background image")
     }
 
     func test_dottedBorder_addsSingleOverlay_and_resetRemovesItOnly() {

--- a/Tests/GIGLibraryTests/GIGUtils/StylableTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/StylableTests.swift
@@ -139,6 +139,23 @@ class StylableTests: XCTestCase {
         XCTAssertNotEqual(sut.backgroundImage(for: .normal), sut.backgroundImage(for: .disabled))
     }
 
+    func test_restyling_Button_clears_stale_disabled_background() {
+        // A reused button first styled by color sets a .disabled dim image. Restyling it
+        // with an explicit backgroundImage must not leave that stale .disabled image behind.
+        let sut = UIButton(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        let textStyle = TextStyle(font: UIFont.systemFont(ofSize: 10))
+        sut.withStyle(ButtonStyle(textStyle: textStyle, viewStyle: ViewStyle(backgroundColor: .red)))
+        XCTAssertNotNil(sut.backgroundImage(for: .disabled), "color style should install a disabled dim image")
+
+        let explicitImage = UIImage.create(from: .blue)
+        sut.withStyle(ButtonStyle(textStyle: textStyle, backgroundImage: explicitImage))
+        XCTAssertEqual(sut.backgroundImage(for: .normal), explicitImage)
+        // No explicit .disabled image now, so UIKit falls back to the new .normal image —
+        // the stale color dim is gone (it would NOT equal the new image if it had leaked).
+        XCTAssertEqual(sut.backgroundImage(for: .disabled), explicitImage,
+                       "stale disabled dim must be cleared so the new style's image is used")
+    }
+
     func test_dottedBorder_addsSingleOverlay_and_resetRemovesItOnly() {
         // C030/C031: the dashed border is a dedicated overlay subview. Applying it must add
         // exactly one overlay (no accumulation on re-style), resetBorders must remove that


### PR DESCRIPTION
## Auditoría de release — Sesión S3 (módulo `GIGUtils/Style/`)

10 hallazgos cohesivos sobre el subsistema de estilos. Un solo PR.

### Cambios por hallazgo

| Item | Tipo | Archivo | Fix |
|------|------|---------|-----|
| **C027** | bug | `UIButton+Stylable` | El dim del 30% del estado disabled se grababa en `backgroundColor` y **se quedaba pegado al re-habilitar** (`backgroundColor` no es por-estado). Ahora la apariencia se conduce con imágenes de fondo por-estado (`.normal`/`.disabled`), que UIKit restaura solo al cambiar `isEnabled`. |
| **C028** | bug | `UIString+Stylable` | `letterSpacing` (kern) se ignoraba si `isStrikedThrough == true` (estaba en el `else` del tachado). Ahora se aplica en su propio `if` independiente. |
| **C070** | bug | `UIString+Stylable` | `strikethroughStyle` usaba el literal mágico `2` (= `.thick`); ahora `NSUnderlineStyle.single.rawValue`, coherente con el subrayado. |
| **C029** | dead-code | `TextViewStyle` | Eliminado `borderStyle`: `UITextView` no tiene `borderStyle` y `UITextView+Stylable` nunca lo leía (copy-paste de `TextFieldStyle`). El borde se cubre vía `viewStyle`. |
| **C030** | correctness | `UIView+Borders` | `resetBorders()` borraba **todos** los `CAShapeLayer` del host (eliminaba capas ajenas: gradientes, progreso, terceros). Ahora solo quita los overlays propios (`BorderView`/`DottedBorderView`). |
| **C031** | bug | `UIView+Borders` | El dotted border construía el path con `self.bounds` **pre-layout** (≈`.zero`) y no se reajustaba en rotación/resize. Reescrito como subvista `DottedBorderView` pinneada que recalcula el path en `layoutSubviews`. |
| **C074** | dead-code | `UIView+Borders` / `View+Extension` | Eliminado el `roundCorners(corners:radius:)` duplicado (sin llamadores en la librería). Al `roundCorners(_:radius:)` superviviente se le añade `mask.frame` para no perder esa corrección. |
| **C071** | api-design | `ViewStyle` | Default `backgroundColor` `.white` → `.clear`: aplicar un `ViewStyle` ya no pinta de blanco (rompía dark mode); coherente con `TextStyle`. |
| **C072** | tech-debt | `ViewStyle` / `ButtonStyle` | Doc duplicada eliminada; typos corregidos (`attributted`→`attributed`, `not apply`→`is not applied`, `Label`→`Button`). |
| **C073** | api-design | `ViewStyle` | Propiedades `var` → `let` (struct inmutable, coherente con `TextStyle`/`LabelStyle`). |

### ⚠️ Cambios source-breaking (para changelog)

Dos símbolos de API **pública** se eliminan:

1. **`TextViewStyle.init(... borderStyle:)`** (C029): desaparece el parámetro público `borderStyle`.
2. **`UIView.roundCorners(corners:radius:)`** (C074): este método estaba en `public extension UIView` en `develop` (verificado), no era internal como sugería la nota de auditoría. No tiene llamadores dentro de la librería, pero puede tenerlos en apps consumidoras. Se mantiene el otro overload público `roundCorners(_:radius:)`.

### Nota conocida (no regresión)

Con `cornerRadius` + `masksToBounds = true`, el trazo dasheado de `DottedBorderView` (centrado sobre el path pinneado a `bounds`) se clipea a ~mitad de grosor. Es comportamiento **preexistente** (el approach anterior sobre el layer del host sufría lo mismo); fuera del scope de C030/C031. Mitigable a futuro insettando el path en `lineWidth/2`.

### Verificación

- ✅ `xcodebuild ... test` — 183 tests, **TEST SUCCEEDED**
- ✅ `swiftlint` — 0 violaciones
- ✅ Build **Release** — 0 warnings (Swift 6.2 strict concurrency)
- ✅ Revisión `ios-pr-reviewer`: aprobado; sin data races; concurrencia OK
- Tests añadidos/actualizados: C027 (disabled no persiste dim), C028 (kern aplicado con tachado), C070 (`strikethroughStyle == .single`), C030/C031 (`addDottedBorder`/`resetBorders` añaden un único overlay y no tocan subvistas/capas ajenas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Actualización — C027 (fondo de botón) y API nueva

El fix de C027 evolucionó tras la revisión de Codex sobre el enfoque inicial:

- **Enfoque inicial** (imágenes de fondo por-estado): introducía dos regresiones — borraba el fondo en restilados text-only y **congelaba colores dinámicos** (`.systemBackground`, asset colors) al renderizarlos a un `UIImage` 1×1, rompiendo dark mode (contradiciendo C071).
- **Resolución**: se asigna `backgroundColor` directamente (re-resuelve colores dinámicos) y se elimina el manejo de imágenes por-estado. El restilado text-only ya no toca el fondo.
- **Fondo de disabled state-aware** (nueva API pública, additiva): `StyledButton: UIButton` aplica un `backgroundColor` por-estado intercambiándolo en el `didSet` de `isEnabled` — state-aware (no se queda pegado al re-habilitar) y dynamic-safe (asigna `UIColor`, no imagen). Se activa con el nuevo campo opcional `ButtonStyle.disabledBackgroundColor` (default `nil` → comportamiento sin cambios). Un `UIButton` plano lo ignora (documentado). Es la opción de fix que el propio audit sugería para C027 ("un color disabled explícito en el estilo").

**Adiciones de API pública** (no breaking): `StyledButton`, `ButtonStyle.disabledBackgroundColor`.