### PR TITLE
fix(Image): S5 audit fixes for ImageDownloader & loadGif (C017/C018/C019/C049/C050)

### DIFF
--- a/.claude/rules/networking.md
+++ b/.claude/rules/networking.md
@@ -157,7 +157,7 @@ In tests: inject `NetworkLogManagerSpy` via the designated `init` to capture log
 - `fetch()` **never throws** — always check `Response.status` before using `Response.data`
 - `fetchDecodable` and `fetchVoid` **do** throw — wrap in `do/catch`
 - `Response.image(scale:)` is `nonisolated` and takes the screen scale explicitly — decode GIFs off the main actor (read `UIScreen.main.scale` on main, then call from a background task) so a large/multi-frame network GIF can't block the UI
-- `Response.image(scale:)` decodes `.gif` URLs as animated images (via `UIImage.gif(data:)`); other URLs decode as a single `UIImage` at `scale`
+- `Response.image(scale:)` decodes GIFs as animated images (via `UIImage.gif(data:)`) when the URL ends in `.gif` **or** the body starts with the `GIF8` signature; everything else decodes as a single `UIImage` at `scale`
 - `.gigigo` standard type marks the response as failed on `{ "status": false }` even with HTTP 200 — intentional
 - `fetch()` silently returns a `.noInternet` response if reachability check fails — no exception is raised
 - Only HTTP `200..<300` is `.success`; `300`+ map to an error status

--- a/Sources/GIGLibrary/GIGUtils/Image/ImageDownloader.swift
+++ b/Sources/GIGLibrary/GIGUtils/Image/ImageDownloader.swift
@@ -97,7 +97,13 @@ struct ImageDownloader {
 
     // MARK: - Public methods
 
-    func download(url: String, for view: UIImageView, placeholder: UIImage?) {
+    /// Cancels and forgets any in-flight or still-queued download for `view`, without starting a new
+    /// one. Used by `UIImageView.loadGif(name:)` and the local-file branch of `loadGif(urlString:)`
+    /// so that switching a (possibly reused) view to a local GIF decode invalidates a still-pending
+    /// remote download for the same view — otherwise the older remote download could complete
+    /// afterward and paint over the newer local result, breaking the last-request-wins guarantee
+    /// across the `loadGif` APIs.
+    func cancelPendingDownload(for view: UIImageView) {
         if let pending = ImageDownloader.queue[view] {
             pending.request.cancel()
             ImageDownloader.queue.removeValue(forKey: view)
@@ -105,6 +111,10 @@ struct ImageDownloader {
             // `fetch()` will unwind through `handleResponse` and release the slot there; if it
             // was still pending in `stack`, it was never counted and `pump()` skips its entry.
         }
+    }
+
+    func download(url: String, for view: UIImageView, placeholder: UIImage?) {
+        self.cancelPendingDownload(for: view)
         if let image = ImageDownloader.images.object(forKey: url as NSString) {
             view.image = image
         } else {

--- a/Sources/GIGLibrary/GIGUtils/Image/ImageDownloader.swift
+++ b/Sources/GIGLibrary/GIGUtils/Image/ImageDownloader.swift
@@ -12,9 +12,28 @@ import UIKit
 struct ImageDownloader {
 
     static let shared = ImageDownloader()
-    static var queue: [UIImageView: Request] = [:]
+    static var queue: [UIImageView: PendingDownload] = [:]
     static var stack: [UIImageView] = []
-    static var images: [String: UIImage] = [:]
+
+    /// In-memory image cache. `NSCache` (instead of a plain dictionary) bounds the footprint
+    /// automatically: it evicts under memory pressure, honours `countLimit`, and is purged on
+    /// memory warnings — so it cannot grow without bound the way a dictionary did. Keyed by the
+    /// original request URL string captured from the caller (see `PendingDownload.url`), which is
+    /// the single source of truth for both lookup and store.
+    static let images: NSCache<NSString, UIImage> = {
+        let cache = NSCache<NSString, UIImage>()
+        cache.countLimit = ImageDownloaderConfiguration.defaultMaxCachedImages
+        return cache
+    }()
+
+    /// A download in flight (or queued) for a view: the `Request` used to compare identity on
+    /// completion, plus the original `url` string captured from the caller. The `url` is the single
+    /// source of truth for the cache key — used unchanged for both lookup and store — so the key
+    /// cannot diverge if `Request` ever starts transforming its `baseURL`.
+    struct PendingDownload {
+        let request: Request
+        let url: String
+    }
 
     /// Number of downloads currently in flight: a `fetch()` has been started and has not yet
     /// reached a terminal handler. Views still waiting in `stack` are NOT counted.
@@ -39,10 +58,10 @@ struct ImageDownloader {
 
     /// Seam used only by DEBUG builds: fired on the MainActor immediately after a successful
     /// download's decode → resize step has written the image to `images`, carrying the cache key
-    /// (`request.baseURL`). It lets tests await that step deterministically instead of polling with
-    /// a timeout, so they cannot flake when the `.utility` resize task is scheduled late under CI
-    /// load — they wait for the real signal rather than racing a deadline. `nil` by default and
-    /// absent from release builds — see `handleResponse(_:view:request:)`.
+    /// (`PendingDownload.url`). It lets tests await that step deterministically instead of polling
+    /// with a timeout, so they cannot flake when the `.utility` resize task is scheduled late under
+    /// CI load — they wait for the real signal rather than racing a deadline. `nil` by default and
+    /// absent from release builds — see `handleResponse(_:view:request:url:)`.
     static var didCacheImageForTesting: (@MainActor (_ cacheKey: String) -> Void)?
     #endif
 
@@ -65,7 +84,7 @@ struct ImageDownloader {
     private init() {
         NotificationCenter.default.addObserver(forName: UIApplication.didReceiveMemoryWarningNotification, object: nil, queue: .main) { _ in
             Task { @MainActor in
-                ImageDownloader.images = [:]
+                ImageDownloader.images.removeAllObjects()
                 ImageDownloader.stack = []
                 ImageDownloader.queue = [:]
                 // Intentionally do NOT reset `activeDownloads`: the in-flight fetches keep running
@@ -79,14 +98,14 @@ struct ImageDownloader {
     // MARK: - Public methods
 
     func download(url: String, for view: UIImageView, placeholder: UIImage?) {
-        if let request = ImageDownloader.queue[view] {
-            request.cancel()
+        if let pending = ImageDownloader.queue[view] {
+            pending.request.cancel()
             ImageDownloader.queue.removeValue(forKey: view)
             // Do NOT touch `activeDownloads` here. If the request was already in flight, its
             // `fetch()` will unwind through `handleResponse` and release the slot there; if it
             // was still pending in `stack`, it was never counted and `pump()` skips its entry.
         }
-        if let image = ImageDownloader.images[url] {
+        if let image = ImageDownloader.images.object(forKey: url as NSString) {
             view.image = image
         } else {
             view.image = placeholder
@@ -102,7 +121,7 @@ struct ImageDownloader {
         #else
         let request = Request(method: .get, baseUrl: url, endpoint: "", bodyParams: nil)
         #endif
-        ImageDownloader.queue[view] = request
+        ImageDownloader.queue[view] = PendingDownload(request: request, url: url)
         // Drop any stale pending entry for this view before re-enqueuing it, so a view that was
         // re-requested while still queued (e.g. a reused cell) is never started more than once.
         ImageDownloader.stack.removeAll { $0 === view }
@@ -123,7 +142,9 @@ struct ImageDownloader {
 
     /// The single place that increments `activeDownloads` and launches a fetch.
     private func startDownload(for view: UIImageView) {
-        guard let request = ImageDownloader.queue[view] else { return }
+        guard let pending = ImageDownloader.queue[view] else { return }
+        let request = pending.request
+        let url = pending.url
         ImageDownloader.activeDownloads += 1
         // Unstructured Task is required here: `fetch()` is `@concurrent` (it runs off the
         // MainActor) and must be bridged from this MainActor-isolated flow, which is driven by
@@ -134,7 +155,7 @@ struct ImageDownloader {
             // `fetch()` installs its in-flight canceller, so if this request is no longer the
             // current one for the view, release the slot here instead of letting a discarded
             // download occupy it (and hit the network) until it finishes.
-            guard ImageDownloader.queue[view] === request else {
+            guard ImageDownloader.queue[view]?.request === request else {
                 self.finishDownload()
                 return
             }
@@ -143,7 +164,7 @@ struct ImageDownloader {
             #else
             let response = await request.fetch()
             #endif
-            self.handleResponse(response, view: view, request: request)
+            self.handleResponse(response, view: view, request: request, url: url)
         }
     }
 
@@ -158,12 +179,12 @@ struct ImageDownloader {
     /// identity (not URL). A stale completion must never evict a newer request's entry for the same
     /// reused view — even when both target the same URL.
     private func clearQueueEntry(for view: UIImageView, ifCurrent request: Request) {
-        if ImageDownloader.queue[view] === request {
+        if ImageDownloader.queue[view]?.request === request {
             ImageDownloader.queue.removeValue(forKey: view)
         }
     }
 
-    private func handleResponse(_ response: Response, view: UIImageView, request: Request) {
+    private func handleResponse(_ response: Response, view: UIImageView, request: Request, url: String) {
         switch response.status {
         case .success:
             // Read the scale and target size on the main actor (UIKit), then release the download
@@ -195,12 +216,12 @@ struct ImageDownloader {
                     // view was reused, even for the same URL) never paints over the newer request,
                     // and a completion whose entry was purged by a memory warning does NOT refill
                     // the cache the app was trying to free.
-                    guard ImageDownloader.queue[view] === request else { return }
+                    guard ImageDownloader.queue[view]?.request === request else { return }
                     self.setAnimated(image: finalImage, in: view)
-                    ImageDownloader.images[request.baseURL] = finalImage
+                    ImageDownloader.images.setObject(finalImage, forKey: url as NSString)
                     ImageDownloader.queue.removeValue(forKey: view)
                     #if DEBUG
-                    ImageDownloader.didCacheImageForTesting?(request.baseURL)
+                    ImageDownloader.didCacheImageForTesting?(url)
                     #endif
                 }
             }

--- a/Sources/GIGLibrary/GIGUtils/Image/ImageDownloaderConfiguration.swift
+++ b/Sources/GIGLibrary/GIGUtils/Image/ImageDownloaderConfiguration.swift
@@ -25,4 +25,18 @@ public enum ImageDownloaderConfiguration {
         get { ImageDownloader.maxConcurrentDownloads }
         set { ImageDownloader.maxConcurrentDownloads = newValue }
     }
+
+    /// Default upper bound on the number of images kept in the in-memory cache. Applied to the
+    /// `NSCache` when it is first created; `NSCache` still evicts earlier under memory pressure.
+    static let defaultMaxCachedImages = 100
+
+    /// Maximum number of images kept in the in-memory cache.
+    ///
+    /// Backed by `NSCache.countLimit`, which is **best-effort**: the cache may briefly exceed this
+    /// count before it evicts. A value of `0` means "no count limit" (eviction then happens only
+    /// under memory pressure). Defaults to `defaultMaxCachedImages`. Negative values are clamped to `0`.
+    public static var maxCachedImages: Int {
+        get { ImageDownloader.images.countLimit }
+        set { ImageDownloader.images.countLimit = max(0, newValue) }
+    }
 }

--- a/Sources/GIGLibrary/GIGUtils/Image/UIImage+Extension.swift
+++ b/Sources/GIGLibrary/GIGUtils/Image/UIImage+Extension.swift
@@ -15,24 +15,73 @@ public extension UIImageView {
         ImageDownloader.shared.download(url: urlString, for: self, placeholder: placeholder)
     }
     
+    /// Loads a GIF bundled with the app by resource name, decoding it off the main actor.
+    ///
+    /// Decoding runs on a background executor so a large/multi-frame GIF cannot block the UI, and
+    /// the result is only applied if this call is still the most recent `loadGif(name:)` for the
+    /// view — a reused cell that fires two loads in a row shows the LAST one requested, not
+    /// whichever finishes decoding last (see `gifLoadGeneration`). A decode failure leaves the
+    /// current image untouched instead of blanking it.
     func loadGif(name: String) {
-        DispatchQueue.global().async {
-            let image = UIImage.gif(name: name)
-            DispatchQueue.main.async {
+        let generation = beginGifLoad()
+        // Unstructured Task: this is a synchronous UIKit entry point (not an async context), so the
+        // off-main `decodedGif` must be bridged here. The generation guard drops a stale result if
+        // the view is reused before the decode finishes.
+        Task { @MainActor in
+            let image = await UIImage.decodedGif(name: name)
+            if self.gifLoadGeneration == generation, let image {
                 self.image = image
             }
+            #if DEBUG
+            UIImageView.didFinishLoadGifNameForTesting?()
+            #endif
         }
     }
-    
+
+    /// Loads a remote GIF through `ImageDownloader`, reusing its managed download path: async and
+    /// cancellable network I/O (no synchronous `Data(contentsOf:)` on a background thread), a
+    /// bounded concurrency limit, an in-memory cache, and the view-identity guard that makes a
+    /// reused cell show the last URL requested. The current image is passed as the placeholder so a
+    /// failed load leaves it untouched rather than blanking the view.
+    ///
+    /// The response is decoded as an animated GIF when the URL ends in `.gif` or its bytes carry a
+    /// GIF signature (see `Response.image`), so a GIF served from an extensionless URL still animates.
     func loadGif(urlString: String) {
-        DispatchQueue.global().async {
-            let image = UIImage.gif(url: urlString)
-            DispatchQueue.main.async {
-                self.image = image
-            }
-        }
+        ImageDownloader.shared.download(url: urlString, for: self, placeholder: self.image)
     }
 }
+
+// MARK: - loadGif(name:) view identity
+
+private extension UIImageView {
+
+    /// Monotonic per-view counter identifying the most recent `loadGif(name:)` request, stored as an
+    /// associated object. Compared on completion so a stale decode (the view was reused) is dropped.
+    /// The 1-byte allocation is only ever used for its stable address as the association key and is
+    /// intentionally never freed — it lives for the process lifetime, like a `static` sentinel.
+    private static let gifLoadGenerationKey = UnsafeRawPointer(UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1))
+
+    var gifLoadGeneration: Int {
+        (objc_getAssociatedObject(self, UIImageView.gifLoadGenerationKey) as? Int) ?? 0
+    }
+
+    /// Bumps the generation for this view and returns the new value, marking any in-flight
+    /// `loadGif(name:)` decode as stale.
+    func beginGifLoad() -> Int {
+        let next = gifLoadGeneration &+ 1
+        objc_setAssociatedObject(self, UIImageView.gifLoadGenerationKey, next, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return next
+    }
+}
+
+#if DEBUG
+extension UIImageView {
+    /// DEBUG-only seam fired on the MainActor after a `loadGif(name:)` decode completes (whether or
+    /// not the image was applied), so tests can await the real completion instead of sleeping. `nil`
+    /// by default and absent from release builds. Mirrors `ImageDownloader.didCacheImageForTesting`.
+    static var didFinishLoadGifNameForTesting: (@MainActor () -> Void)?
+}
+#endif
 
 extension UIImage {
     
@@ -54,19 +103,26 @@ extension UIImage {
         return UIImage.animatedImageWithSource(source)
     }
     
+    /// Loads a GIF from a URL string by reading its bytes synchronously with `Data(contentsOf:)`.
+    ///
+    /// - Warning: For a **remote** URL this performs blocking network I/O with no timeout,
+    ///   cancellation, or concurrency limit — which the library forbids for downloads. Use
+    ///   `UIImageView.loadGif(urlString:)` (managed, async, cancellable) for remote GIFs, or
+    ///   `gif(data:)` once you already hold the bytes. Kept only for loading a local `file://` URL.
+    @available(*, deprecated, message: "For remote URLs use UIImageView.loadGif(urlString:) (async, cancellable); for bytes you already hold use gif(data:). This does blocking network I/O.")
     public class func gif(url: String) -> UIImage? {
         // Validate URL
         guard let bundleURL = URL(string: url) else {
             LogWarn("This image named \"\(url)\" does not exist")
             return nil
         }
-        
+
         // Validate data
         guard let imageData = try? Data(contentsOf: bundleURL) else {
             LogWarn("Cannot turn image named \"\(url)\" into NSData")
             return nil
         }
-        
+
         return gif(data: imageData)
     }
     
@@ -77,14 +133,23 @@ extension UIImage {
             LogWarn("This image named \"\(name)\" does not exist")
             return nil
         }
-        
+
         // Validate data
         guard let imageData = try? Data(contentsOf: bundleURL) else {
             LogWarn("Cannot turn image named \"\(name)\" into NSData")
             return nil
         }
-        
+
         return gif(data: imageData)
+    }
+
+    /// Decodes a bundled GIF by name off the main actor. `@concurrent` forces the (potentially heavy,
+    /// multi-frame) decode onto a background executor instead of the caller's actor, and the
+    /// `sending` result lets the freshly-created, non-`Sendable` `UIImage` cross back to the
+    /// `@MainActor` caller in `UIImageView.loadGif(name:)`.
+    @concurrent
+    static func decodedGif(name: String) async -> sending UIImage? {
+        UIImage.gif(name: name)
     }
     
     public func imageProportionally(with size: CGSize) -> UIImage? {

--- a/Sources/GIGLibrary/GIGUtils/Image/UIImage+Extension.swift
+++ b/Sources/GIGLibrary/GIGUtils/Image/UIImage+Extension.swift
@@ -18,46 +18,51 @@ public extension UIImageView {
     /// Loads a GIF bundled with the app by resource name, decoding it off the main actor.
     ///
     /// Decoding runs on a background executor so a large/multi-frame GIF cannot block the UI, and
-    /// the result is only applied if this call is still the most recent `loadGif(name:)` for the
-    /// view — a reused cell that fires two loads in a row shows the LAST one requested, not
-    /// whichever finishes decoding last (see `gifLoadGeneration`). A decode failure leaves the
-    /// current image untouched instead of blanking it.
+    /// the result is only applied if this call is still the most recent local-decode request for the
+    /// view (see `gifLoadGeneration`) — the same guard shared with the local-file branch of
+    /// `loadGif(urlString:)`, so a reused cell always shows whichever load (name, local file, or
+    /// remote) was requested LAST, never whichever finishes decoding first. Also cancels any pending
+    /// remote download for this view, so an older `loadGif(urlString:)` cannot complete afterward and
+    /// paint over this one. A decode failure leaves the current image untouched instead of blanking it.
     func loadGif(name: String) {
-        let generation = beginGifLoad()
-        // Unstructured Task: this is a synchronous UIKit entry point (not an async context), so the
-        // off-main `decodedGif` must be bridged here. The generation guard drops a stale result if
-        // the view is reused before the decode finishes.
-        Task { @MainActor in
-            let image = await UIImage.decodedGif(name: name)
-            if self.gifLoadGeneration == generation, let image {
-                self.image = image
-            }
-            #if DEBUG
-            UIImageView.didFinishLoadGifNameForTesting?()
-            #endif
-        }
+        ImageDownloader.shared.cancelPendingDownload(for: self)
+        self.loadGifLocally { await UIImage.decodedGif(name: name) }
     }
 
-    /// Loads a remote GIF through `ImageDownloader`, reusing its managed download path: async and
-    /// cancellable network I/O (no synchronous `Data(contentsOf:)` on a background thread), a
-    /// bounded concurrency limit, an in-memory cache, and the view-identity guard that makes a
-    /// reused cell show the last URL requested. The current image is passed as the placeholder so a
-    /// failed load leaves it untouched rather than blanking the view.
+    /// Loads a GIF from `urlString`. A `file://` URL is decoded locally and off-main, sharing the
+    /// same last-request-wins guard as `loadGif(name:)` — it never goes through `ImageDownloader`,
+    /// which would otherwise run `Request`'s reachability precheck and fail with `.noInternet` for a
+    /// purely local read. Any other URL is treated as remote and loaded through `ImageDownloader`'s
+    /// managed path: async and cancellable network I/O (no synchronous `Data(contentsOf:)` on a
+    /// background thread), a bounded concurrency limit, an in-memory cache, and the view-identity
+    /// guard that makes a reused cell show the last URL requested. The current image is passed as the
+    /// placeholder so a failed load leaves it untouched rather than blanking the view.
     ///
     /// The response is decoded as an animated GIF when the URL ends in `.gif` or its bytes carry a
     /// GIF signature (see `Response.image`), so a GIF served from an extensionless URL still animates.
     func loadGif(urlString: String) {
+        if let url = URL(string: urlString), url.isFileURL {
+            ImageDownloader.shared.cancelPendingDownload(for: self)
+            self.loadGifLocally { await UIImage.decodedGif(fileURL: url) }
+            return
+        }
+        // Bumping the generation invalidates any pending local decode (`loadGif(name:)` or a
+        // local-file `loadGif(urlString:)`) for this (possibly reused) view, so it cannot paint over
+        // this remote request if it resolves afterward.
+        _ = self.beginGifLoad()
         ImageDownloader.shared.download(url: urlString, for: self, placeholder: self.image)
     }
 }
 
-// MARK: - loadGif(name:) view identity
+// MARK: - loadGif view identity
 
 private extension UIImageView {
 
-    /// Monotonic per-view counter identifying the most recent `loadGif(name:)` request, stored as an
-    /// associated object. Compared on completion so a stale decode (the view was reused) is dropped.
-    /// The 1-byte allocation is only ever used for its stable address as the association key and is
+    /// Monotonic per-view counter identifying the most recent local-decode request (`loadGif(name:)`
+    /// or the local-file branch of `loadGif(urlString:)`), stored as an associated object, and also
+    /// bumped by the remote branch of `loadGif(urlString:)` to invalidate a pending local decode.
+    /// Compared on completion so a stale decode (the view was reused) is dropped. The 1-byte
+    /// allocation is only ever used for its stable address as the association key and is
     /// intentionally never freed — it lives for the process lifetime, like a `static` sentinel.
     private static let gifLoadGenerationKey = UnsafeRawPointer(UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1))
 
@@ -65,21 +70,40 @@ private extension UIImageView {
         (objc_getAssociatedObject(self, UIImageView.gifLoadGenerationKey) as? Int) ?? 0
     }
 
-    /// Bumps the generation for this view and returns the new value, marking any in-flight
-    /// `loadGif(name:)` decode as stale.
+    /// Bumps the generation for this view and returns the new value, marking any in-flight local
+    /// decode as stale.
     func beginGifLoad() -> Int {
         let next = gifLoadGeneration &+ 1
         objc_setAssociatedObject(self, UIImageView.gifLoadGenerationKey, next, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         return next
     }
+
+    /// Shared local-decode path for `loadGif(name:)` and the local-file branch of
+    /// `loadGif(urlString:)`: bumps the generation, decodes off-main via `decode`, and applies the
+    /// result only if this is still the most recent local-decode request for the view.
+    func loadGifLocally(_ decode: @escaping @Sendable () async -> UIImage?) {
+        let generation = beginGifLoad()
+        // Unstructured Task: this is a synchronous UIKit entry point (not an async context), so the
+        // off-main decode must be bridged here.
+        Task { @MainActor in
+            let image = await decode()
+            if self.gifLoadGeneration == generation, let image {
+                self.image = image
+            }
+            #if DEBUG
+            UIImageView.didFinishLocalGifDecodeForTesting?()
+            #endif
+        }
+    }
 }
 
 #if DEBUG
 extension UIImageView {
-    /// DEBUG-only seam fired on the MainActor after a `loadGif(name:)` decode completes (whether or
-    /// not the image was applied), so tests can await the real completion instead of sleeping. `nil`
-    /// by default and absent from release builds. Mirrors `ImageDownloader.didCacheImageForTesting`.
-    static var didFinishLoadGifNameForTesting: (@MainActor () -> Void)?
+    /// DEBUG-only seam fired on the MainActor after a local GIF decode (`loadGif(name:)` or the
+    /// local-file branch of `loadGif(urlString:)`) completes (whether or not the image was applied),
+    /// so tests can await the real completion instead of sleeping. `nil` by default and absent from
+    /// release builds. Mirrors `ImageDownloader.didCacheImageForTesting`.
+    static var didFinishLocalGifDecodeForTesting: (@MainActor () -> Void)?
 }
 #endif
 
@@ -151,7 +175,19 @@ extension UIImage {
     static func decodedGif(name: String) async -> sending UIImage? {
         UIImage.gif(name: name)
     }
-    
+
+    /// Decodes a GIF from a local `file://` URL off the main actor. Reads local disk data directly —
+    /// not the network I/O `gif(url:)` is deprecated for — so it needs no reachability check and
+    /// works offline. `@concurrent`/`sending` mirror `decodedGif(name:)`.
+    @concurrent
+    static func decodedGif(fileURL: URL) async -> sending UIImage? {
+        guard let imageData = try? Data(contentsOf: fileURL) else {
+            LogWarn("Cannot turn image at \"\(fileURL)\" into NSData")
+            return nil
+        }
+        return gif(data: imageData)
+    }
+
     public func imageProportionally(with size: CGSize) -> UIImage? {
         // If the target/source sizes are degenerate (e.g. a zero-bounds `UIImageView` in
         // `ImageDownloader.handleResponse`), `aspectFillSize` returns nil and the original image is

--- a/Sources/GIGLibrary/SwiftNetwork/Response.swift
+++ b/Sources/GIGLibrary/SwiftNetwork/Response.swift
@@ -118,7 +118,8 @@ public class Response: Selfie, @unchecked Sendable {
     /// `.gif` body can carry many/large frames and is network-controlled, so the (potentially heavy)
     /// decode must run off the main actor — `ImageDownloader` reads the scale on the main actor and
     /// then calls this from a detached task. GIFs decode as animated images; everything else as a
-    /// single frame at `scale`.
+    /// single frame at `scale`. A GIF is recognised by the response URL's `.gif` extension OR the
+    /// body's `GIF8` signature, so a GIF served from a URL without a `.gif` path still animates.
     func image(scale: CGFloat) throws -> UIImage {
 		guard let imageData = self.body else {
 			throw ResponseError.bodyNil
@@ -127,7 +128,9 @@ public class Response: Selfie, @unchecked Sendable {
         // GIFs need the animated decoder: `UIImage(data:)` only yields the first frame, and the
         // previous code rejected them outright — so a managed download (e.g. `ImageDownloader`)
         // spent a network slot only to discard the result silently. Decode them properly here.
-        if self.isGifURL() {
+        // Detect GIFs by the URL extension OR the raw bytes' signature: a GIF served from a URL
+        // without a `.gif` path (e.g. a CDN endpoint) would otherwise be flattened to a single frame.
+        if self.isGifURL() || Response.dataHasGIFHeader(imageData) {
             guard let image = UIImage.gif(data: imageData) else {
                 throw ResponseError.unexpectedDataType
             }
@@ -178,6 +181,20 @@ public class Response: Selfie, @unchecked Sendable {
             return false
         }
         return url.pathExtension.caseInsensitiveCompare("gif") == .orderedSame
+    }
+
+    /// True when the raw bytes begin with a GIF signature (`GIF87a`/`GIF89a`, both sharing the
+    /// `GIF8` prefix). Used alongside the URL extension so a GIF whose URL has no `.gif` path is
+    /// still decoded as animated rather than flattened to a single frame. No other common image
+    /// format starts with these bytes, so PNG/JPEG bodies fall through to the single-frame decode.
+    /// Indexed from `startIndex` so it is correct even when `data` is a slice.
+    private static func dataHasGIFHeader(_ data: Data) -> Bool {
+        guard data.count >= 4 else { return false }
+        let start = data.startIndex
+        return data[start] == 0x47      // G
+            && data[start + 1] == 0x49  // I
+            && data[start + 2] == 0x46  // F
+            && data[start + 3] == 0x38  // 8
     }
 
     private func shouldParseJSON(headers: [AnyHashable: Any]?, body: Data?) -> Bool {

--- a/Tests/GIGLibraryTests/GIGUtils/ImageDownloaderTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/ImageDownloaderTests.swift
@@ -292,6 +292,58 @@ struct ImageDownloaderTests {
         #expect(drained)
     }
 
+    // MARK: - loadGif cross-invalidation (mixed name:/urlString: usage on a reused view)
+
+    @Test("Given a view mid-remote-load, when it is reused for loadGif(name:), then the pending remote download is cancelled")
+    func loadGifNameCancelsPendingRemoteDownload() async {
+        ImageDownloader.resetForTesting()
+        useFailFastRequests()
+
+        let view = makeImageView()
+        view.loadGif(urlString: "https://example.com/reused-then-name.gif")
+        // Registered synchronously before any await, same reasoning as the routing test above.
+        #expect(ImageDownloader.queue[view] != nil)
+
+        // Reusing the view for a bundled GIF must cancel the still-pending remote download (Codex
+        // P2): otherwise it could complete afterward and paint over the bundled result.
+        view.loadGif(name: "___missing_resource_that_does_not_exist___")
+        #expect(ImageDownloader.queue[view] == nil)
+
+        let drained = await waitUntil { ImageDownloader.activeDownloads == 0 }
+        #expect(drained)
+    }
+
+    @Test("Given a view mid-local-decode, when reused for loadGif(urlString:) with a remote URL, then the remote result wins")
+    func loadGifURLStringRemoteInvalidatesPendingLocalDecode() async throws {
+        ImageDownloader.resetForTesting()
+        let remoteURL = "https://example.com/remote-after-local.gif"
+        ImageDownloader.fetchProvider = { _ in
+            makeImageResponse(body: makePNGData(), url: URL(fileURLWithPath: "/remote-after-local.png"))
+        }
+
+        // A real local GIF so the local decode would actually succeed if it were allowed to apply.
+        let gifData = try #require(Data(base64Encoded: "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"))
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".gif")
+        try gifData.write(to: tempURL)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        // Simulates a reused cell: a local-file GIF load immediately superseded by a remote one.
+        let view = makeImageView()
+        view.loadGif(urlString: tempURL.absoluteString)
+        view.loadGif(urlString: remoteURL)
+
+        await awaitCache(of: remoteURL)
+
+        // The remote load must win (Codex P2): the local decode's generation was bumped stale
+        // before it could resolve, so it cannot overwrite the remote result even if it finishes late.
+        let cachedRemote = ImageDownloader.images.object(forKey: remoteURL as NSString)
+        #expect(cachedRemote != nil)
+        #expect(view.image === cachedRemote)
+
+        let drained = await waitUntil { ImageDownloader.activeDownloads == 0 }
+        #expect(drained)
+    }
+
     // MARK: - Cache hit
 
     @Test("Given a cached URL, when requested, then no download starts and the cached image is assigned")

--- a/Tests/GIGLibraryTests/GIGUtils/ImageDownloaderTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/ImageDownloaderTests.swift
@@ -26,6 +26,27 @@ struct ImageDownloaderTests {
         #expect(ImageDownloaderConfiguration.maxConcurrentDownloads == 1)
     }
 
+    @Test("Given a reset downloader, then the default max cached images is 100")
+    func defaultMaxCachedImagesIsHundred() {
+        ImageDownloader.resetForTesting()
+
+        #expect(ImageDownloaderConfiguration.maxCachedImages == ImageDownloaderConfiguration.defaultMaxCachedImages)
+    }
+
+    @Test("Given a value for max cached images, when set, then it is stored and negatives clamp to 0")
+    func maxCachedImagesStoresAndClamps() {
+        ImageDownloader.resetForTesting()
+
+        ImageDownloaderConfiguration.maxCachedImages = 50
+        #expect(ImageDownloaderConfiguration.maxCachedImages == 50)
+
+        ImageDownloaderConfiguration.maxCachedImages = -10
+        #expect(ImageDownloaderConfiguration.maxCachedImages == 0)
+
+        // Restore the default so later tests observe the standard cache limit.
+        ImageDownloader.resetForTesting()
+    }
+
     // MARK: - Concurrency limit
 
     @Test("Given a max of 2, when 5 downloads are requested in one tick, then only 2 are active and 3 stay queued")
@@ -78,8 +99,9 @@ struct ImageDownloaderTests {
         let urlString = "https://example.com/success.png"
         // Inject a PNG response directly instead of going through URLSession, whose stalls under CI
         // load (NSURLError -1001) made this test flaky. The success path (decode → resize → cache)
-        // still runs for real. The Response's `url` is only nominal — the cache key is
-        // `request.baseURL` — so any valid URL works. See `ImageDownloader.fetchProvider`.
+        // still runs for real. The Response's `url` is only nominal — the cache key is the caller's
+        // original URL string (`PendingDownload.url`), independent of the Response's own `url`, so
+        // any valid response URL works. See `ImageDownloader.fetchProvider`.
         ImageDownloader.fetchProvider = { _ in
             makeImageResponse(body: makePNGData(), url: URL(fileURLWithPath: "/success.png"))
         }
@@ -93,7 +115,7 @@ struct ImageDownloaderTests {
         // of polling: under CI load the `.utility` resize task can be scheduled late, which used to
         // exhaust `waitUntil`'s deadline and flake. See `awaitCache`.
         await awaitCache(of: urlString)
-        #expect(ImageDownloader.images[urlString] != nil)
+        #expect(ImageDownloader.images.object(forKey: urlString as NSString) != nil)
         #expect(ImageDownloader.activeDownloads == 0)
     }
 
@@ -213,9 +235,61 @@ struct ImageDownloaderTests {
         ImageDownloader.shared.download(url: urlString, for: view, placeholder: nil)
 
         await awaitCache(of: urlString)
-        #expect(ImageDownloader.images[urlString] != nil)
-        #expect(ImageDownloader.images[urlString]?.images != nil)
+        #expect(ImageDownloader.images.object(forKey: urlString as NSString) != nil)
+        #expect(ImageDownloader.images.object(forKey: urlString as NSString)?.images != nil)
         #expect(ImageDownloader.activeDownloads == 0)
+    }
+
+    // MARK: - loadGif(urlString:) routing
+
+    @Test("Given loadGif(urlString:), when called, then it routes through the managed download path")
+    func loadGifURLStringRoutesThroughImageDownloader() async {
+        ImageDownloader.resetForTesting()
+        useFailFastRequests()
+
+        let view = makeImageView()
+        view.loadGif(urlString: "https://example.com/animation.gif")
+
+        // A managed download is registered for the view (async/cancellable path), rather than the
+        // old synchronous `Data(contentsOf:)` on a background thread. Checked before draining: this
+        // is `@MainActor` so `download()` enqueues synchronously (before any `await`), and the
+        // fail-fast request clears the entry once it unwinds, so the entry only exists pre-drain.
+        #expect(ImageDownloader.queue[view] != nil)
+
+        let drained = await waitUntil { ImageDownloader.activeDownloads == 0 }
+        #expect(drained)
+    }
+
+    @Test("Given loadGif(urlString:) called twice on a reused view, when both resolve, then the view shows the last URL and only it is cached")
+    func loadGifURLStringReusedViewShowsLastImage() async {
+        ImageDownloader.resetForTesting()
+        let firstURL = "https://example.com/first.gif"
+        let secondURL = "https://example.com/second.gif"
+        // Both requests would decode to a valid image; which one paints is decided by the view
+        // identity guard, not by which finishes first. See `ImageDownloader.fetchProvider`.
+        ImageDownloader.fetchProvider = { _ in
+            makeImageResponse(body: makePNGData(), url: URL(fileURLWithPath: "/reused.png"))
+        }
+
+        // Simulates a reused cell: two GIF loads in quick succession on the same view.
+        let view = makeImageView()
+        view.loadGif(urlString: firstURL)
+        view.loadGif(urlString: secondURL)
+
+        // Await the last URL's cache write deterministically.
+        await awaitCache(of: secondURL)
+
+        // Observable outcome: the last-requested URL is the one that completes, caches, and paints;
+        // the replaced first request is dropped by the identity guard before it can fetch, so it
+        // never populates the cache. `handleResponse` paints and caches the SAME decoded instance,
+        // so the view showing exactly the second URL's image is asserted by identity.
+        let cachedSecond = ImageDownloader.images.object(forKey: secondURL as NSString)
+        #expect(cachedSecond != nil)
+        #expect(ImageDownloader.images.object(forKey: firstURL as NSString) == nil)
+        #expect(view.image === cachedSecond)
+
+        let drained = await waitUntil { ImageDownloader.activeDownloads == 0 }
+        #expect(drained)
     }
 
     // MARK: - Cache hit
@@ -225,7 +299,7 @@ struct ImageDownloaderTests {
         ImageDownloader.resetForTesting()
         let urlString = "https://example.com/cached.png"
         let cached = makeImage(.blue)
-        ImageDownloader.images[urlString] = cached
+        ImageDownloader.images.setObject(cached, forKey: urlString as NSString)
 
         let view = makeImageView()
         ImageDownloader.shared.download(url: urlString, for: view, placeholder: nil)
@@ -306,7 +380,8 @@ extension ImageDownloader {
     static func resetForTesting() {
         queue = [:]
         stack = []
-        images = [:]
+        images.removeAllObjects()
+        images.countLimit = ImageDownloaderConfiguration.defaultMaxCachedImages
         activeDownloads = 0
         maxConcurrentDownloads = 6  // setter clamps and pumps (a no-op while the stack is empty)
         requestProvider = { url in Request(method: .get, baseUrl: url, endpoint: "", bodyParams: nil) }

--- a/Tests/GIGLibraryTests/GIGUtils/UIImageExtensionTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/UIImageExtensionTests.swift
@@ -3,7 +3,11 @@ import UIKit
 @testable import GIGLibrary
 
 @MainActor
-@Suite("UIImage+Extension")
+// Serialized: `loadGifNameMissingPreservesImage` installs the global `UIImageView`
+// `didFinishLoadGifNameForTesting` seam and consumes it via a `CheckedContinuation`. Parallel tests
+// touching that shared static could resume the continuation twice (a trap), so the suite runs serially
+// — same rationale as `ImageDownloaderTests`.
+@Suite("UIImage+Extension", .serialized)
 struct UIImageExtensionTests {
 
     // MARK: - imageProportionally guards
@@ -115,6 +119,31 @@ struct UIImageExtensionTests {
           ])
     func aspectFillSizeRejectsDegenerate(source: CGSize, target: CGSize) {
         #expect(UIImage.aspectFillSize(for: source, fitting: target) == nil)
+    }
+
+    // MARK: - loadGif(name:) failure handling
+
+    @Test("Given loadGif(name:) with a missing resource, when the decode fails, then the existing image is preserved")
+    func loadGifNameMissingPreservesImage() async {
+        let view = UIImageView()
+        let existing = makeImage(size: CGSize(width: 4, height: 4))
+        view.image = existing
+
+        // Await the real decode-completion signal instead of sleeping, so the assertion runs AFTER
+        // the (nil) decode was handled — proving the image was preserved because the failed decode
+        // was skipped, not merely because the background task had not run yet. Installing the hook
+        // before `loadGif` is safe: this is `@MainActor`, so the load's `@MainActor` task cannot run
+        // until we suspend at the continuation below.
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            UIImageView.didFinishLoadGifNameForTesting = {
+                UIImageView.didFinishLoadGifNameForTesting = nil
+                continuation.resume()
+            }
+            view.loadGif(name: "___missing_resource_that_does_not_exist___")
+        }
+
+        // A failed decode must not blank the view (C050): the previous image stays untouched.
+        #expect(view.image === existing)
     }
 
     // MARK: - Helpers

--- a/Tests/GIGLibraryTests/GIGUtils/UIImageExtensionTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/UIImageExtensionTests.swift
@@ -4,9 +4,9 @@ import UIKit
 
 @MainActor
 // Serialized: `loadGifNameMissingPreservesImage` installs the global `UIImageView`
-// `didFinishLoadGifNameForTesting` seam and consumes it via a `CheckedContinuation`. Parallel tests
-// touching that shared static could resume the continuation twice (a trap), so the suite runs serially
-// — same rationale as `ImageDownloaderTests`.
+// `didFinishLocalGifDecodeForTesting` seam and consumes it via a `CheckedContinuation`. Parallel
+// tests touching that shared static could resume the continuation twice (a trap), so the suite runs
+// serially — same rationale as `ImageDownloaderTests`.
 @Suite("UIImage+Extension", .serialized)
 struct UIImageExtensionTests {
 
@@ -135,8 +135,8 @@ struct UIImageExtensionTests {
         // before `loadGif` is safe: this is `@MainActor`, so the load's `@MainActor` task cannot run
         // until we suspend at the continuation below.
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            UIImageView.didFinishLoadGifNameForTesting = {
-                UIImageView.didFinishLoadGifNameForTesting = nil
+            UIImageView.didFinishLocalGifDecodeForTesting = {
+                UIImageView.didFinishLocalGifDecodeForTesting = nil
                 continuation.resume()
             }
             view.loadGif(name: "___missing_resource_that_does_not_exist___")
@@ -146,7 +146,36 @@ struct UIImageExtensionTests {
         #expect(view.image === existing)
     }
 
+    // MARK: - loadGif(urlString:) local file handling
+
+    @Test("Given loadGif(urlString:) with a local file:// URL, when the file has valid GIF data, then it decodes locally without going through ImageDownloader")
+    func loadGifURLStringLocalFileDecodesWithoutImageDownloader() async throws {
+        ImageDownloader.resetForTesting()
+        let gifData = try #require(Data(base64Encoded: "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"))
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".gif")
+        try gifData.write(to: tempURL)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let view = makeImageView()
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            UIImageView.didFinishLocalGifDecodeForTesting = {
+                UIImageView.didFinishLocalGifDecodeForTesting = nil
+                continuation.resume()
+            }
+            view.loadGif(urlString: tempURL.absoluteString)
+        }
+
+        // A `file://` URL must never touch ImageDownloader's network path (no reachability
+        // precheck, no queue entry) — otherwise a purely local read would fail offline (Codex P2).
+        #expect(ImageDownloader.queue[view] == nil)
+        #expect(view.image?.images != nil)
+    }
+
     // MARK: - Helpers
+
+    private func makeImageView() -> UIImageView {
+        return UIImageView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+    }
 
     /// Builds a solid-colour image of an exact point size at scale 1, so `.size` assertions are
     /// deterministic and independent of the device screen scale.

--- a/Tests/GIGLibraryTests/SwiftNetwork/ResponseTests.swift
+++ b/Tests/GIGLibraryTests/SwiftNetwork/ResponseTests.swift
@@ -245,6 +245,21 @@ struct ResponseTests {
         #expect(image.size.height > 0)
     }
 
+    @Test("Given valid GIF data at a URL without a .gif extension, when image is requested, then it still decodes as animated")
+    func imageDecodesGifDataFromExtensionlessURL() throws {
+        // Given a minimal 1x1 GIF89a served from a CDN-style URL with no `.gif` path
+        let gifData = try #require(Data(base64Encoded: "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"))
+        let url = try #require(URL(string: "https://cdn.example.com/media?id=123"))
+        let response = makeImageResponse(body: gifData, url: url)
+
+        // When
+        let image = try response.image(scale: 1)
+
+        // Then the `GIF8` byte signature routes it through the animated decoder despite the URL
+        // extension not being `.gif`, instead of flattening it to a single frame.
+        #expect(image.images != nil)
+    }
+
     @Test("Given HTTP status codes around the 2xx boundary, when Response parses, then only 200..<300 are success")
     func responseTreatsOnly2xxAsSuccess() throws {
         // Given


### PR DESCRIPTION
## Summary

S5 release-audit fixes for GIGLibrary's Image module (`ImageDownloader`, `UIImage+Extension`), addressing 5 findings:

- **C017 (memory-leak)**: `ImageDownloader.images` migrated from an unbounded `[String: UIImage]` to `NSCache<NSString, UIImage>` — auto-evicts under memory pressure, purges on memory warnings, and exposes a new `ImageDownloaderConfiguration.maxCachedImages` knob (default 100).
- **C049 (correctness)**: cache key is now a single source of truth — the caller's original `url` string (carried in `PendingDownload`), used identically for lookup and store, instead of `Request.baseURL` (which could diverge).
- **C050 (bug)**: `loadGif` no longer blanks the current image on a decode failure.
- **C019 (performance/bug)**: `loadGif(urlString:)` now delegates to `ImageDownloader`'s managed path — async/cancellable network I/O, bounded concurrency, caching — instead of a blocking `Data(contentsOf:)` on a background thread. The old blocking `UIImage.gif(url:)` is deprecated toward this path.
- **C018 (concurrency)**: both `loadGif` variants now guard against the reused-cell race — `loadGif(name:)` via a per-view generation token (`objc_associatedObject`), `loadGif(urlString:)` via `ImageDownloader`'s existing view-identity guard — so the LAST-requested image always wins, not whichever finishes decoding first.

Also fixes a regression surfaced during review: `Response.image(scale:)` now recognizes an animated GIF by its `GIF8` byte signature in addition to the `.gif` URL extension, so a GIF served from an extensionless URL still animates instead of being flattened to a single frame.

## Why

Found during the ongoing GIGLibrary release audit (image-loading module). `loadGif` was a parallel, unmanaged path that reintroduced the exact reused-cell bug `ImageDownloader` had already solved, plus an unbounded cache and a blocking-network-I/O violation of this repo's async/await rules.

## Test plan

- [x] `xcodebuild -scheme GIGLibrary -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' test` — 216 tests passing
- [x] `swiftlint` — 0 warnings
- [x] `xcodebuild -scheme GIGLibrary -configuration Release ... build` — 0 warnings (confirms Swift 6.2 StrictConcurrency is clean; Debug incremental builds can hide these)
- [x] New regression tests: reused-view "last request wins" for both `loadGif` variants, decode-failure preserves the existing image, GIF-by-content-signature decoding, `maxCachedImages` clamping
- [x] Went through multiple rounds of automated PR review (`ios-pr-reviewer`) with fixes applied each round until a clean pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)