### PR TITLE
fix(Image): S5b — kill flaky ImageDownloader suite race + invalidate pending gif decode in image(from:)

### DIFF
--- a/Sources/GIGLibrary/GIGUtils/Image/UIImage+Extension.swift
+++ b/Sources/GIGLibrary/GIGUtils/Image/UIImage+Extension.swift
@@ -10,8 +10,13 @@ import UIKit
 import ImageIO
 
 public extension UIImageView {
-    
+
     func image(from urlString: String, placeholder: UIImage?) {
+        // Bumping the generation invalidates any pending local GIF decode (`loadGif(name:)` or a
+        // local-file `loadGif(urlString:)`) for this (possibly reused) view, so a decode captured
+        // before this call cannot paint over the image loaded here if it resolves afterward — the
+        // same last-request-wins guard the remote branch of `loadGif(urlString:)` already applies.
+        _ = self.beginGifLoad()
         ImageDownloader.shared.download(url: urlString, for: self, placeholder: placeholder)
     }
     

--- a/Tests/GIGLibraryTests/GIGUtils/ImageDownloaderTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/ImageDownloaderTests.swift
@@ -344,6 +344,100 @@ struct ImageDownloaderTests {
         #expect(drained)
     }
 
+    // MARK: - loadGif local decode (name: / local file://)
+
+    @Test("Given loadGif(name:) with a missing resource, when the decode fails, then the existing image is preserved")
+    func loadGifNameMissingPreservesImage() async {
+        ImageDownloader.resetForTesting()
+        let view = UIImageView()
+        let existing = makeImage(size: CGSize(width: 4, height: 4))
+        view.image = existing
+
+        // Await the real decode-completion signal instead of sleeping, so the assertion runs AFTER
+        // the (nil) decode was handled — proving the image was preserved because the failed decode
+        // was skipped, not merely because the background task had not run yet. Installing the hook
+        // before `loadGif` is safe: this is `@MainActor`, so the load's `@MainActor` task cannot run
+        // until we suspend at the continuation below.
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            UIImageView.didFinishLocalGifDecodeForTesting = {
+                UIImageView.didFinishLocalGifDecodeForTesting = nil
+                continuation.resume()
+            }
+            view.loadGif(name: "___missing_resource_that_does_not_exist___")
+        }
+
+        // A failed decode must not blank the view (C050): the previous image stays untouched.
+        #expect(view.image === existing)
+    }
+
+    @Test("Given loadGif(urlString:) with a local file:// URL, when the file has valid GIF data, then it decodes locally without going through ImageDownloader")
+    func loadGifURLStringLocalFileDecodesWithoutImageDownloader() async throws {
+        ImageDownloader.resetForTesting()
+        let gifData = try #require(Data(base64Encoded: "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"))
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".gif")
+        try gifData.write(to: tempURL)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let view = makeImageView()
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            UIImageView.didFinishLocalGifDecodeForTesting = {
+                UIImageView.didFinishLocalGifDecodeForTesting = nil
+                continuation.resume()
+            }
+            view.loadGif(urlString: tempURL.absoluteString)
+        }
+
+        // A `file://` URL must never touch ImageDownloader's network path (no reachability
+        // precheck, no queue entry) — otherwise a purely local read would fail offline (Codex P2).
+        #expect(ImageDownloader.queue[view] == nil)
+        #expect(view.image?.images != nil)
+    }
+
+    @Test("Given a view mid-local-GIF-decode, when reused for image(from:), then the stale local decode does not paint over image(from:)")
+    func imageFromInvalidatesPendingLocalGifDecode() async throws {
+        ImageDownloader.resetForTesting()
+        useFailFastRequests()
+
+        // A real local GIF so the local decode actually produces an image and WOULD paint if it were
+        // still considered current — a nil decode could otherwise mask the bug. The `file://` branch
+        // of `loadGif(urlString:)` shares the exact `gifLoadGeneration` guard as `loadGif(name:)`
+        // (both go through `loadGifLocally`), and unlike a bundled resource it can be decoded from
+        // the test bundle, so it faithfully exercises the `name:` → `image(from:)` reuse scenario.
+        let gifData = try #require(Data(base64Encoded: "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"))
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".gif")
+        try gifData.write(to: tempURL)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        // A non-animated marker so the assertion can tell image(from:)'s result apart from the GIF.
+        let placeholder = makeImage(.blue)
+
+        let view = makeImageView()
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            UIImageView.didFinishLocalGifDecodeForTesting = {
+                UIImageView.didFinishLocalGifDecodeForTesting = nil
+                continuation.resume()
+            }
+            // Simulates a reused cell mixing the GIF and remote-image APIs:
+            // 1. Start a local GIF decode (captures the current generation).
+            view.loadGif(urlString: tempURL.absoluteString)
+            // 2. Reuse the same view for image(from:). These two calls run synchronously with no
+            //    suspension point before the await below, so the local decode's `@MainActor` task
+            //    cannot interleave — image(from:)'s (synchronous) generation bump is guaranteed to
+            //    land first. The fail-fast request never paints, so `placeholder` is the last thing
+            //    image(from:) writes to the view.
+            view.image(from: "https://example.com/reused-then-remote.png", placeholder: placeholder)
+        }
+
+        // With the generation bump now in image(from:), the local decode is stale by the time it
+        // resolves and must NOT overwrite image(from:)'s result: the marker placeholder stays and
+        // the view is never left showing the animated GIF.
+        #expect(view.image === placeholder)
+        #expect(view.image?.images == nil)
+
+        let drained = await waitUntil { ImageDownloader.activeDownloads == 0 }
+        #expect(drained)
+    }
+
     // MARK: - Cache hit
 
     @Test("Given a cached URL, when requested, then no download starts and the cached image is assigned")
@@ -384,6 +478,18 @@ struct ImageDownloaderTests {
 
     private func makeImage(_ color: UIColor) -> UIImage {
         return UIImage.create(from: color) ?? UIImage()
+    }
+
+    /// Builds a solid-colour, non-animated image of an exact point size at scale 1, so `.size`
+    /// assertions are deterministic and `.images == nil` distinguishes it from a decoded GIF.
+    private func makeImage(size: CGSize, color: UIColor = .red) -> UIImage {
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = 1
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
+        return renderer.image { context in
+            color.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+        }
     }
 
     private func makePNGData() -> Data {

--- a/Tests/GIGLibraryTests/GIGUtils/UIImageExtensionTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/UIImageExtensionTests.swift
@@ -3,11 +3,11 @@ import UIKit
 @testable import GIGLibrary
 
 @MainActor
-// Serialized: `loadGifNameMissingPreservesImage` installs the global `UIImageView`
-// `didFinishLocalGifDecodeForTesting` seam and consumes it via a `CheckedContinuation`. Parallel
-// tests touching that shared static could resume the continuation twice (a trap), so the suite runs
-// serially — same rationale as `ImageDownloaderTests`.
-@Suite("UIImage+Extension", .serialized)
+// Every test here is pure size math on locally-built images — none touch `ImageDownloader`'s
+// shared static state or the `UIImageView.didFinishLocalGifDecodeForTesting` seam. The `loadGif`
+// tests that DO touch that shared state live in `ImageDownloaderTests` (a `.serialized` suite), so
+// this suite needs no serialization and cannot race another suite over global state.
+@Suite("UIImage+Extension")
 struct UIImageExtensionTests {
 
     // MARK: - imageProportionally guards
@@ -121,61 +121,7 @@ struct UIImageExtensionTests {
         #expect(UIImage.aspectFillSize(for: source, fitting: target) == nil)
     }
 
-    // MARK: - loadGif(name:) failure handling
-
-    @Test("Given loadGif(name:) with a missing resource, when the decode fails, then the existing image is preserved")
-    func loadGifNameMissingPreservesImage() async {
-        let view = UIImageView()
-        let existing = makeImage(size: CGSize(width: 4, height: 4))
-        view.image = existing
-
-        // Await the real decode-completion signal instead of sleeping, so the assertion runs AFTER
-        // the (nil) decode was handled — proving the image was preserved because the failed decode
-        // was skipped, not merely because the background task had not run yet. Installing the hook
-        // before `loadGif` is safe: this is `@MainActor`, so the load's `@MainActor` task cannot run
-        // until we suspend at the continuation below.
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            UIImageView.didFinishLocalGifDecodeForTesting = {
-                UIImageView.didFinishLocalGifDecodeForTesting = nil
-                continuation.resume()
-            }
-            view.loadGif(name: "___missing_resource_that_does_not_exist___")
-        }
-
-        // A failed decode must not blank the view (C050): the previous image stays untouched.
-        #expect(view.image === existing)
-    }
-
-    // MARK: - loadGif(urlString:) local file handling
-
-    @Test("Given loadGif(urlString:) with a local file:// URL, when the file has valid GIF data, then it decodes locally without going through ImageDownloader")
-    func loadGifURLStringLocalFileDecodesWithoutImageDownloader() async throws {
-        ImageDownloader.resetForTesting()
-        let gifData = try #require(Data(base64Encoded: "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"))
-        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".gif")
-        try gifData.write(to: tempURL)
-        defer { try? FileManager.default.removeItem(at: tempURL) }
-
-        let view = makeImageView()
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            UIImageView.didFinishLocalGifDecodeForTesting = {
-                UIImageView.didFinishLocalGifDecodeForTesting = nil
-                continuation.resume()
-            }
-            view.loadGif(urlString: tempURL.absoluteString)
-        }
-
-        // A `file://` URL must never touch ImageDownloader's network path (no reachability
-        // precheck, no queue entry) — otherwise a purely local read would fail offline (Codex P2).
-        #expect(ImageDownloader.queue[view] == nil)
-        #expect(view.image?.images != nil)
-    }
-
     // MARK: - Helpers
-
-    private func makeImageView() -> UIImageView {
-        return UIImageView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
-    }
 
     /// Builds a solid-colour image of an exact point size at scale 1, so `.size` assertions are
     /// deterministic and independent of the device screen scale.


### PR DESCRIPTION
## Contexto

Seguimiento **S5b** de la auditoría de release de GIGLibrary (S5 ya en `develop`, `e8f1c73`). Dos arreglos diagnosticados y confirmados.

## 1. Test flaky (~50%) — race entre suites

**Causa raíz:** `UIImageExtensionTests` era una `@Suite` separada que también mutaba el estado global `static` de `ImageDownloader` (`resetForTesting()`, `queue`, y el seam `didFinishLocalGifDecodeForTesting`). El trait `.serialized` de Swift Testing **solo serializa dentro de una misma suite**, no entre suites distintas, así que corría en paralelo con `ImageDownloaderTests`. Si `UIImageExtensionTests` ejecutaba `resetForTesting()` mientras `successReleasesSlotAndCaches()` esperaba en `awaitCache(of:)`, el reset ponía `didCacheImageForTesting = nil`, borrando el callback instalado → el `CheckedContinuation` nunca se resolvía y el test colgaba hasta el `.timeLimit` de 60 s.

**Fix:** mover los dos tests de `loadGif` que tocan estado compartido a `ImageDownloaderTests` (la suite ya `.serialized` que además ya albergaba los demás tests de `loadGif`). `UIImageExtensionTests` queda como math puro de tamaños (`imageProportionally`/`aspectFillSize`), sin estado compartido, por lo que ninguna suite puede pisar el estado global de otra. Se elimina su `.serialized` (ya innecesario).

## 2. Hueco de identidad en `image(from:)`

`loadGif(urlString:)` (rama remota) bumpea `gifLoadGeneration` vía `beginGifLoad()` antes de delegar en `ImageDownloader`, invalidando cualquier decode local pendiente. Pero `image(from:placeholder:)` llamaba a `ImageDownloader.shared.download(...)` **directamente**, sin ese bump. En una celda reutilizada que mezclara APIs (`loadGif(name:)` → reutilización → `image(from:)`), el decode GIF local pendiente podía terminar después y pintar el GIF viejo **sobre** la imagen remota más nueva.

**Fix:** añadir `_ = self.beginGifLoad()` al inicio de `image(from:placeholder:)`, aplicando el mismo guard de última-petición-gana. Como el bump es **síncrono**, un decode local capturado antes queda obsoleto en cuanto se llama a `image(from:)`.

**Test de regresión:** `imageFromInvalidatesPendingLocalGifDecode` ejercita `loadGif(file://)` → `image(from:)` sobre la misma vista reutilizada. Determinista: ambas llamadas corren síncronamente sin punto de suspensión antes del `await`, así que el bump de generación de `image(from:)` gana antes de que la `Task` del decode local pueda correr. Se usa la rama `file://` (mismo mecanismo `loadGifLocally`/`gifLoadGeneration` que `loadGif(name:)`) porque un recurso `name:` del bundle no es decodificable desde el bundle de tests, pero un `file://` sí. Verificado: con el fix revertido el test falla (`view.image` es el `_UIAnimatedImage`); con el fix, pasa.

## Verificación

- ✅ Suite completa (`xcodebuild`, iPhone 17 Pro): **220 tests**, 3/3 ejecuciones fiables.
- ✅ Par flaky (`ImageDownloaderTests` + `UIImageExtensionTests`): **10/10** pasadas.
- ✅ Test de regresión validado: falla con el fix revertido, pasa con el fix.
- ✅ **SwiftLint** 0 warnings.
- ✅ **Build Release** (`-configuration Release`) sin warnings de StrictConcurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)