### PR TITLE
fix(GIGUtils): S7 audit — JSON subscript traversal & CoreData helper safety (C014/C016/C044/C048)

### DIFF
--- a/Sources/GIGLibrary/GIGUtils/CoreData/NSManagedObjectContext+Extension.swift
+++ b/Sources/GIGLibrary/GIGUtils/CoreData/NSManagedObjectContext+Extension.swift
@@ -11,9 +11,10 @@ import CoreData
 
 public extension NSManagedObjectContext {
 
-	/// Inserts a new managed object for `name`, executed on the context's own queue via
-	/// `performAndWait` so it is safe to call from any thread. Returns `nil` if the entity
-	/// name is unknown to the model.
+	/// Inserts a new managed object for `name`. The insertion runs on the context's own queue via
+	/// `performAndWait`, but the returned `NSManagedObject` is confined to that queue: read or
+	/// mutate it only on the context's queue (e.g. inside `context.perform`/`performAndWait`, or on
+	/// the main thread for a main-queue context). Returns `nil` if the entity name is unknown.
     func createEntity(_ name: String) -> NSManagedObject? {
 		self.performAndWait {
 			guard let entity = NSEntityDescription.entity(forEntityName: name, in: self) else {
@@ -24,10 +25,11 @@ public extension NSManagedObjectContext {
 		}
 	}
 
-	/// Fetches the first object of `entityName` matching `predicate` (all objects if `nil`).
-	/// Runs on the context's queue and propagates any underlying Core Data fetch error instead
-	/// of swallowing it. The `predicate` is a pre-built `NSPredicate`, so callers cannot inject
-	/// an unbound format string.
+	/// Fetches the first object of `entityName` matching `predicate` (all objects if `nil`). The
+	/// fetch runs on the context's queue and propagates any underlying Core Data error instead of
+	/// swallowing it. The returned object is confined to the context's queue — use it only on that
+	/// queue. The `predicate` is a pre-built `NSPredicate`, so callers cannot inject an unbound
+	/// format string.
     func fetchFirst(_ entityName: String, predicate: NSPredicate? = nil) throws -> NSManagedObject? {
 		// `NSPredicate` is not `Sendable`, but it is only read synchronously on the context's own
 		// queue inside `performAndWait` — it never actually crosses to another thread.
@@ -41,10 +43,11 @@ public extension NSManagedObjectContext {
 		}
 	}
 
-	/// Fetches all objects of `entityName` matching `predicate` (all objects if `nil`).
-	/// Runs on the context's queue and propagates any underlying Core Data fetch error instead
-	/// of swallowing it. The `predicate` is a pre-built `NSPredicate`, so callers cannot inject
-	/// an unbound format string.
+	/// Fetches all objects of `entityName` matching `predicate` (all objects if `nil`). The fetch
+	/// runs on the context's queue and propagates any underlying Core Data error instead of
+	/// swallowing it. The returned objects are confined to the context's queue — use them only on
+	/// that queue. The `predicate` is a pre-built `NSPredicate`, so callers cannot inject an unbound
+	/// format string.
     func fetchList(_ entityName: String, predicate: NSPredicate? = nil) throws -> [NSManagedObject] {
 		// `NSPredicate` is not `Sendable`, but it is only read synchronously on the context's own
 		// queue inside `performAndWait` — it never actually crosses to another thread.

--- a/Sources/GIGLibrary/GIGUtils/CoreData/NSManagedObjectContext+Extension.swift
+++ b/Sources/GIGLibrary/GIGUtils/CoreData/NSManagedObjectContext+Extension.swift
@@ -10,26 +10,50 @@ import Foundation
 import CoreData
 
 public extension NSManagedObjectContext {
-	
+
+	/// Inserts a new managed object for `name`, executed on the context's own queue via
+	/// `performAndWait` so it is safe to call from any thread. Returns `nil` if the entity
+	/// name is unknown to the model.
     func createEntity(_ name: String) -> NSManagedObject? {
-		guard let entity = NSEntityDescription.entity(forEntityName: name, in: self) else {
-			return nil
+		self.performAndWait {
+			guard let entity = NSEntityDescription.entity(forEntityName: name, in: self) else {
+				return nil
+			}
+
+			return NSManagedObject(entity: entity, insertInto: self)
 		}
-		
-		return NSManagedObject(entity: entity, insertInto: self)
 	}
-	
-    func fetchFirst(_ entityName: String, predicateString: String) -> NSManagedObject? {
-		let result = self.fetchList(entityName, predicateString: predicateString)
-		return result?.first
+
+	/// Fetches the first object of `entityName` matching `predicate` (all objects if `nil`).
+	/// Runs on the context's queue and propagates any underlying Core Data fetch error instead
+	/// of swallowing it. The `predicate` is a pre-built `NSPredicate`, so callers cannot inject
+	/// an unbound format string.
+    func fetchFirst(_ entityName: String, predicate: NSPredicate? = nil) throws -> NSManagedObject? {
+		// `NSPredicate` is not `Sendable`, but it is only read synchronously on the context's own
+		// queue inside `performAndWait` — it never actually crosses to another thread.
+		nonisolated(unsafe) let predicate = predicate
+		return try self.performAndWait {
+			let fetch = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
+			fetch.predicate = predicate
+			fetch.fetchLimit = 1
+
+			return try self.fetch(fetch).first as? NSManagedObject
+		}
 	}
-	
-    func fetchList(_ entityName: String, predicateString: String) -> [NSManagedObject]? {
-        let fetch: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest(entityName: entityName)
-		fetch.predicate = NSPredicate(format: predicateString)
-		
-		let results = try? self.fetch(fetch)
-		
-		return results as? [NSManagedObject]
+
+	/// Fetches all objects of `entityName` matching `predicate` (all objects if `nil`).
+	/// Runs on the context's queue and propagates any underlying Core Data fetch error instead
+	/// of swallowing it. The `predicate` is a pre-built `NSPredicate`, so callers cannot inject
+	/// an unbound format string.
+    func fetchList(_ entityName: String, predicate: NSPredicate? = nil) throws -> [NSManagedObject] {
+		// `NSPredicate` is not `Sendable`, but it is only read synchronously on the context's own
+		// queue inside `performAndWait` — it never actually crosses to another thread.
+		nonisolated(unsafe) let predicate = predicate
+		return try self.performAndWait {
+			let fetch = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
+			fetch.predicate = predicate
+
+			return try self.fetch(fetch).compactMap { $0 as? NSManagedObject }
+		}
 	}
 }

--- a/Sources/GIGLibrary/GIGUtils/SwiftJson/Json.swift
+++ b/Sources/GIGLibrary/GIGUtils/SwiftJson/Json.swift
@@ -9,14 +9,15 @@
 import Foundation
 
 
-/// `@unchecked Sendable` is sound by design under one invariant: `json` is a `let` populated once in
-/// `init(from:)` and never reassigned or mutated afterwards. Every other method is read-only — they
-/// cast or serialize `json` without writing to it — so although a `JSON` can cross a concurrency
-/// boundary (it is stored in `Response.data`), only immutable reads ever touch its state. The backing
-/// store is `Any` (JSON parsed via `JSONSerialization`, i.e. Foundation value/immutable types), which
-/// the compiler cannot prove `Sendable`; the `@unchecked` annotation asserts the immutability
-/// invariant above in its place, consistent with `Request`/`Response`/`LogManager`.
-public final class JSON: Sequence, CustomStringConvertible, @unchecked Sendable {
+/// `JSON` is intentionally **not** `Sendable`. `json` is a `let`, so the reference is never
+/// reassigned, but `init(from:)` is public and stores the value verbatim: a caller can wrap a
+/// mutable reference type (e.g. `NSMutableDictionary`/`NSMutableArray`) and mutate it externally
+/// while `subscript`/`toData()` read it. Claiming `@unchecked Sendable` would only suppress that
+/// data-race warning without making the payload safe, so we don't. `Response` does store a `JSON`
+/// in its `data` and is itself `@unchecked Sendable`, but that is sound because of `Response`'s own
+/// write-once invariant — it builds the `JSON` during `init` and never shares or mutates it
+/// afterwards (see `Response.swift`) — not because `JSON` is thread-safe on its own.
+public final class JSON: Sequence, CustomStringConvertible {
 
 	private let json: Any
 	

--- a/Sources/GIGLibrary/GIGUtils/SwiftJson/Json.swift
+++ b/Sources/GIGLibrary/GIGUtils/SwiftJson/Json.swift
@@ -9,9 +9,16 @@
 import Foundation
 
 
-public final class JSON: Sequence, CustomStringConvertible {
-	
-	private var json: Any
+/// `@unchecked Sendable` is sound by design under one invariant: `json` is a `let` populated once in
+/// `init(from:)` and never reassigned or mutated afterwards. Every other method is read-only — they
+/// cast or serialize `json` without writing to it — so although a `JSON` can cross a concurrency
+/// boundary (it is stored in `Response.data`), only immutable reads ever touch its state. The backing
+/// store is `Any` (JSON parsed via `JSONSerialization`, i.e. Foundation value/immutable types), which
+/// the compiler cannot prove `Sendable`; the `@unchecked` annotation asserts the immutability
+/// invariant above in its place, consistent with `Request`/`Response`/`LogManager`.
+public final class JSON: Sequence, CustomStringConvertible, @unchecked Sendable {
+
+	private let json: Any
 	
 	public var description: String {
 		if let data = try? JSONSerialization.data(withJSONObject: self.json, options: .prettyPrinted) as Data {
@@ -31,27 +38,20 @@ public final class JSON: Sequence, CustomStringConvertible {
 	}
 	
 	public subscript(path: String) -> JSON? {
-		guard var jsonDict = self.json as? [String: Any] else {
-			return nil
-		}
-		
-		var json = self.json
+		var current: Any = self.json
 		let pathArray = path.components(separatedBy: ".")
-		
+
 		for key in pathArray {
-			
-			if let jsonObject = jsonDict[key] {
-				json = jsonObject
-				
-				if let jsonDictNext = jsonObject as? [String: Any] {
-					jsonDict = jsonDictNext
-				}
-			} else {
+			// Traverse from the *current* node: if an intermediate key resolves to a
+			// non-dictionary while path components remain, the cast fails and we return
+			// `nil` instead of silently querying the previous level's dictionary.
+			guard let dict = current as? [String: Any], let next = dict[key] else {
 				return nil
 			}
+			current = next
 		}
-		
-		return JSON(from: json)
+
+		return JSON(from: current)
 	}
     
     public subscript(index: Int) -> JSON? {

--- a/Sources/GIGLibrary/SwiftNetwork/Response.swift
+++ b/Sources/GIGLibrary/SwiftNetwork/Response.swift
@@ -36,9 +36,10 @@ public enum ResponseError: Error {
 /// mutable reference — so although it crosses a concurrency boundary, only one context ever touches
 /// it at a time. Every stored property is therefore exposed as `public private(set)`: consumers read
 /// it, no one outside the type can mutate it post-init. `data` is a `JSON` (a mutable reference
-/// type); it too is built during `init` and neither shared nor mutated afterwards. `JSON` is itself
-/// `@unchecked Sendable` with an immutable (`let`) backing store (see `Json.swift`), so it upholds
-/// the same write-once invariant this type relies on.
+/// type); it too is built during `init` and neither shared nor mutated afterwards. `JSON` is
+/// intentionally *not* `Sendable` — its `Any` payload could be an externally-mutable reference (see
+/// `Json.swift`) — so containing it here is sound precisely because of the write-once invariant
+/// above, not because `JSON` is thread-safe on its own.
 public class Response: Selfie, @unchecked Sendable {
 
 	public private(set) var status: ResponseStatus

--- a/Sources/GIGLibrary/SwiftNetwork/Response.swift
+++ b/Sources/GIGLibrary/SwiftNetwork/Response.swift
@@ -36,8 +36,9 @@ public enum ResponseError: Error {
 /// mutable reference — so although it crosses a concurrency boundary, only one context ever touches
 /// it at a time. Every stored property is therefore exposed as `public private(set)`: consumers read
 /// it, no one outside the type can mutate it post-init. `data` is a `JSON` (a mutable reference
-/// type); it too is built during `init` and neither shared nor mutated afterwards. Hardening `JSON`
-/// itself into a value/Sendable type is tracked separately (C048).
+/// type); it too is built during `init` and neither shared nor mutated afterwards. `JSON` is itself
+/// `@unchecked Sendable` with an immutable (`let`) backing store (see `Json.swift`), so it upholds
+/// the same write-once invariant this type relies on.
 public class Response: Selfie, @unchecked Sendable {
 
 	public private(set) var status: ResponseStatus

--- a/Tests/GIGLibraryTests/GIGUtils/JSONSubscriptTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/JSONSubscriptTests.swift
@@ -1,0 +1,59 @@
+//
+//  JSONSubscriptTests.swift
+//  GIGLibraryTests
+//
+//  Covers the dot-notation path subscript of `JSON` (C016).
+//
+
+import Testing
+@testable import GIGLibrary
+
+@Suite("JSON dot-notation subscript")
+struct JSONSubscriptTests {
+
+	private let json = JSON(from: [
+		"level1": [
+			"level2": [
+				"leaf": "value"
+			],
+			"scalar": "iAmAString"
+		]
+	] as [String: Any])
+
+	@Test("Given a valid nested path, the leaf value is resolved")
+	func nestedPathResolvesLeaf() throws {
+		let leaf = try #require(json["level1.level2.leaf"])
+		#expect(leaf.toString() == "value")
+	}
+
+	@Test("Given a single existing key, the intermediate node is resolved")
+	func singleKeyResolvesNode() throws {
+		let node = try #require(json["level1"])
+		#expect(node.toDictionary()?["scalar"] as? String == "iAmAString")
+	}
+
+	@Test("Given an intermediate key that resolves to a scalar with path remaining, returns nil")
+	func scalarIntermediateWithRemainingPathReturnsNil() {
+		// `level1.scalar` is a String; asking for `.deeper` beyond it must not silently
+		// fall back to a previous level's dictionary — it must fail.
+		#expect(json["level1.scalar.deeper"] == nil)
+	}
+
+	@Test("Given a non-existent key, returns nil")
+	func missingKeyReturnsNil() {
+		#expect(json["level1.nope"] == nil)
+	}
+
+	@Test("Given an empty path, returns nil (the empty key does not exist)")
+	func emptyPathReturnsNil() {
+		// `"".components(separatedBy: ".")` yields `[""]`, so the traversal looks up the
+		// empty-string key, which is absent — pinning the current behavior.
+		#expect(json[""] == nil)
+	}
+
+	@Test("Given a path applied to a non-dictionary root, returns nil")
+	func nonDictionaryRootReturnsNil() {
+		let arrayJSON = JSON(from: [1, 2, 3] as [Any])
+		#expect(arrayJSON["anything"] == nil)
+	}
+}

--- a/Tests/GIGLibraryTests/GIGUtils/NSManagedObjectContextExtensionTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/NSManagedObjectContextExtensionTests.swift
@@ -1,0 +1,102 @@
+//
+//  NSManagedObjectContextExtensionTests.swift
+//  GIGLibraryTests
+//
+//  Covers the Core Data helpers on `NSManagedObjectContext` (C014/C044):
+//  queue-safe execution via `performAndWait`, real error propagation, and
+//  `NSPredicate`-based filtering.
+//
+
+import Testing
+import CoreData
+@testable import GIGLibrary
+
+// `.serialized`: each test spins up a Core Data stack whose model registers the `Item` entity
+// against the generic `NSManagedObject` class. Core Data keeps process-global entity↔class
+// registration state that is not safe to build concurrently, so these must not run in parallel.
+@Suite("NSManagedObjectContext helpers", .serialized)
+struct NSManagedObjectContextExtensionTests {
+
+	/// Builds an in-memory Core Data stack with a single `Item { name: String }` entity.
+	private func makeContext() throws -> NSManagedObjectContext {
+		let model = NSManagedObjectModel()
+
+		let entity = NSEntityDescription()
+		entity.name = "Item"
+		entity.managedObjectClassName = NSStringFromClass(NSManagedObject.self)
+
+		let nameAttr = NSAttributeDescription()
+		nameAttr.name = "name"
+		nameAttr.attributeType = .stringAttributeType
+		nameAttr.isOptional = true
+		entity.properties = [nameAttr]
+
+		model.entities = [entity]
+
+		let container = NSPersistentContainer(name: "TestModel", managedObjectModel: model)
+		let description = NSPersistentStoreDescription()
+		description.type = NSInMemoryStoreType
+		container.persistentStoreDescriptions = [description]
+
+		var loadError: Error?
+		container.loadPersistentStores { _, error in loadError = error }
+		if let loadError { throw loadError }
+
+		return container.viewContext
+	}
+
+	@Test("Given a known entity name, createEntity inserts an object")
+	func createEntityInsertsObject() throws {
+		let context = try makeContext()
+
+		let object = context.createEntity("Item")
+
+		#expect(object != nil)
+		#expect(object?.entity.name == "Item")
+	}
+
+	@Test("Given an unknown entity name, createEntity returns nil")
+	func createEntityUnknownReturnsNil() throws {
+		let context = try makeContext()
+		#expect(context.createEntity("DoesNotExist") == nil)
+	}
+
+	@Test("Given inserted objects, fetchList returns all of them")
+	func fetchListReturnsAll() throws {
+		let context = try makeContext()
+		context.createEntity("Item")?.setValue("a", forKey: "name")
+		context.createEntity("Item")?.setValue("b", forKey: "name")
+
+		let results = try context.fetchList("Item")
+		#expect(results.count == 2)
+	}
+
+	@Test("Given a predicate, fetchList filters results")
+	func fetchListFiltersByPredicate() throws {
+		let context = try makeContext()
+		context.createEntity("Item")?.setValue("keep", forKey: "name")
+		context.createEntity("Item")?.setValue("drop", forKey: "name")
+
+		let results = try context.fetchList("Item", predicate: NSPredicate(format: "name == %@", "keep"))
+		#expect(results.count == 1)
+		#expect(results.first?.value(forKey: "name") as? String == "keep")
+	}
+
+	@Test("Given a matching predicate, fetchFirst returns the object")
+	func fetchFirstReturnsMatch() throws {
+		let context = try makeContext()
+		context.createEntity("Item")?.setValue("target", forKey: "name")
+
+		let object = try context.fetchFirst("Item", predicate: NSPredicate(format: "name == %@", "target"))
+		#expect(object?.value(forKey: "name") as? String == "target")
+	}
+
+	@Test("Given no matching objects, fetchFirst returns nil")
+	func fetchFirstNoMatchReturnsNil() throws {
+		let context = try makeContext()
+		context.createEntity("Item")?.setValue("other", forKey: "name")
+
+		let object = try context.fetchFirst("Item", predicate: NSPredicate(format: "name == %@", "missing"))
+		#expect(object == nil)
+	}
+}


### PR DESCRIPTION
## Resumen

Sesión S7 de la auditoría de release. Cuatro hallazgos en `SwiftJson/Json.swift` y `CoreData/NSManagedObjectContext+Extension.swift`.

## Cambios

### `Json.swift`
- **C016 [bug]** — El subscript dot-notation (`json["a.b.c"]`) resolvía nodos equivocados: mientras avanzaba `json`, seguía consultando el diccionario del nivel *anterior* (`jsonDict`), de modo que una clave intermedia escalar con path pendiente devolvía silenciosamente un valor de otro nivel en vez de `nil`. Ahora la traversal parte del nodo **actual** con un único `guard`; si un intermedio no es diccionario y quedan componentes, devuelve `nil`.
- **C048 [concurrency]** — `json` pasa de `var` a `let` (write-once, nunca reasignado tras `init`). `JSON` se deja **intencionadamente no-`Sendable`**: como `init(from:)` es público y guarda el `Any` verbatim, `let` solo fija la referencia, no el objeto apuntado; un caller podría envolver un `NSMutableDictionary`/`NSMutableArray` y mutarlo externamente mientras `subscript`/`toData()` lo leen. `Response.data` contiene un `JSON` con seguridad gracias a la invariante *write-once* del propio `Response` (`@unchecked Sendable`), no a que `JSON` sea thread-safe. Comentarios en `Json.swift` y `Response.swift` documentan esto.

### `NSManagedObjectContext+Extension.swift`
- **C014 [concurrency]** — `createEntity`/`fetchFirst`/`fetchList` ejecutan la creación/fetch en la cola propia del contexto vía `performAndWait`, en vez de tocar APIs del contexto desde un hilo arbitrario (undefined behavior; `NSManagedObjectContext` no es `Sendable`). Los objetos devueltos siguen confinados a la cola del contexto: la documentación indica que deben usarse solo en esa cola (no se promete "thread-safe desde cualquier hilo").
- **C044 [error-handling]** — `fetchFirst`/`fetchList` son `throws` y propagan el error real del fetch en lugar de tragárselo con `try?` (nil ambiguo). El predicado pasa a ser un `NSPredicate` pre-construido, eliminando la inyección de format string sin bindear.

## ⚠️ Breaking changes (changelog)

Superficie pública de los helpers de CoreData:
- `fetchFirst(_:predicateString:)` → `fetchFirst(_:predicate:) throws`
- `fetchList(_:predicateString:)` → `fetchList(_:predicate:) throws`, devolviendo `[NSManagedObject]` (no-opcional) en vez de `[NSManagedObject]?`
- El predicado ahora es `NSPredicate? = nil` en lugar de `String`.

No hay callers dentro del repo; no existían tests de CoreData previos.

## Tests

Nuevas suites con Swift Testing:
- `JSONSubscriptTests` — happy path anidado, clave intermedia escalar con path pendiente (regresión C016), clave ausente, path vacío, raíz no-diccionario.
- `NSManagedObjectContextExtensionTests` — stack Core Data in-memory; create/fetch/filtrado por `NSPredicate`. La suite es `.serialized` porque cada test construye un stack que muta el registro global entidad↔clase de Core Data, inseguro en paralelo (esto provocaba un crash intermitente en la ejecución paralela de Swift Testing, ya resuelto).

## Verificación

- `xcodebuild ... test` — exit 0, sin reinicios, corrido ×2.
- Build **Release** (clean) — exit 0, **0 warnings** (strict concurrency limpio). Nota: capturar el `NSPredicate` no-`Sendable` en el bloque `@Sendable` de `performAndWait` requiere `nonisolated(unsafe)` (el predicado solo se lee síncronamente en la cola del contexto); sin él Release emite 4 warnings.
- `swiftlint` — 0 violaciones.
- Revisado con `ios-pr-reviewer` (autofix) + review automática de Codex; los P2 de Codex sobre Sendability de `JSON` y confinamiento de managed objects están atendidos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)