### PR TITLE
test(GIGUtils): cerrar gaps de cobertura QRGenerator + ImageDownloader (U2/U6)

### DIFF
--- a/Sources/GIGLibrary/GIGUtils/QRGenerator/QRGenerator.swift
+++ b/Sources/GIGLibrary/GIGUtils/QRGenerator/QRGenerator.swift
@@ -22,7 +22,12 @@ public final class QR {
 	@MainActor
 	public static func generate(_ string: String, onView: UIImageView) {
 		guard let image: CGImage = self.generate(string) else { return }
-		
+
+		// A zero-sized view cannot back a bitmap context: `CGContext(width:0,height:0,...)` returns
+		// nil and we would bail out anyway. Guard explicitly so the degenerate case is intentional
+		// and documented, rather than relying on the context creation failing downstream.
+		guard onView.frame.size.width > 0, onView.frame.size.height > 0 else { return }
+
         let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
         guard let context = CGContext(
             data: nil,

--- a/Tests/GIGLibraryTests/GIGUtils/ImageDownloaderTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/ImageDownloaderTests.swift
@@ -455,6 +455,29 @@ struct ImageDownloaderTests {
         #expect(view.image === cached)
     }
 
+    // MARK: - Memory warning
+
+    @Test("Given a cached image, when a memory warning is posted, then the cache is purged")
+    func memoryWarningPurgesCache() async {
+        ImageDownloader.resetForTesting()
+        // Touch `shared` so the singleton's memory-warning observer is registered (it is installed
+        // in `ImageDownloader`'s private init). `resetForTesting` already accesses `shared` via the
+        // `maxConcurrentDownloads` setter, but assert it explicitly to make the dependency obvious.
+        _ = ImageDownloader.shared
+
+        let urlString = "https://example.com/memory-warning.png"
+        let cached = makeImage(.blue)
+        ImageDownloader.images.setObject(cached, forKey: urlString as NSString)
+        #expect(ImageDownloader.images.object(forKey: urlString as NSString) != nil)
+
+        // The observer clears the cache on the main queue and then hops through a `Task { @MainActor }`,
+        // so the purge is asynchronous — poll until the entry is gone rather than asserting inline.
+        NotificationCenter.default.post(name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
+
+        let purged = await waitUntil { ImageDownloader.images.object(forKey: urlString as NSString) == nil }
+        #expect(purged)
+    }
+
     // MARK: - Helpers
 
     /// Points the downloader at requests that fail fast in `preChecks` (reachability off), so each

--- a/Tests/GIGLibraryTests/GIGUtils/QRGeneratorTests.swift
+++ b/Tests/GIGLibraryTests/GIGUtils/QRGeneratorTests.swift
@@ -1,0 +1,51 @@
+import Testing
+import UIKit
+@testable import GIGLibrary
+
+@Suite("QRGenerator")
+struct QRGeneratorTests {
+
+    // MARK: - generate(_:) -> UIImage?
+
+    @Test("Given a non-empty string, when generating a QR image, then a non-empty image is returned")
+    func generatesImageForNonEmptyString() throws {
+        let image = try #require(QR.generate("hello"))
+
+        #expect(image.size.width > 0)
+        #expect(image.size.height > 0)
+    }
+
+    @Test("Given an empty string, when generating a QR image, then a non-empty image is still returned")
+    func generatesImageForEmptyString() throws {
+        // Fixes the current contract: the CIQRCodeGenerator filter encodes empty data into a valid
+        // (minimal) symbol, so the API returns a real image rather than nil for the empty string.
+        let image = try #require(QR.generate(""))
+
+        #expect(image.size.width > 0)
+        #expect(image.size.height > 0)
+    }
+
+    // MARK: - generate(_:onView:)
+
+    @MainActor
+    @Test("Given a view with a valid frame, when generating onto it, then the view receives an image")
+    func drawsOntoViewWithValidFrame() {
+        let view = UIImageView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+
+        QR.generate("hello", onView: view)
+
+        #expect(view.image != nil)
+    }
+
+    @MainActor
+    @Test("Given a zero-sized view, when generating onto it, then it does not crash and leaves the image unset")
+    func zeroSizedViewDoesNotCrash() {
+        // A `.zero` frame cannot back a bitmap context. This fixes the contract that the degenerate
+        // case is a silent no-op (guarded explicitly in `generate(_:onView:)`) rather than a crash.
+        let view = UIImageView(frame: .zero)
+
+        QR.generate("hello", onView: view)
+
+        #expect(view.image == nil)
+    }
+}


### PR DESCRIPTION
## Resumen

Cierre de los 2 test-gaps menores restantes de la auditoría de release (U1/U3/U4/U5 ya cubiertos en sesiones previas). Solo se añaden **tests** más un pequeño guard defensivo; sin cambios funcionales.

## Cambios

### U2 — `QRGenerator` (`QRGeneratorTests.swift`, nuevo)
- `QR.generate("hello")` → imagen no nil con `size.width/height > 0`.
- Cadena vacía → `CIQRCodeGenerator` codifica un símbolo mínimo válido, así que devuelve imagen (fijado como contrato).
- `generate(_:onView:)` con frame válido → asigna `onView.image`.
- Frame `.zero` → no crashea y deja `image == nil`.
- Guard defensivo explícito en `generate(_:onView:)` (`guard onView.frame.size.width > 0, ...`) para documentar el caso degenerado en vez de depender de que `CGContext` falle. Sin cambio de comportamiento observable.

### U6 — `ImageDownloader` observer de memory warning (`ImageDownloaderTests.swift`)
- Test que cachea una imagen, postea `didReceiveMemoryWarningNotification` y verifica que la caché se vacía.
- Vive dentro de la suite `@Suite(.serialized)` existente porque toca el estado estático compartido de `ImageDownloader`.

## Verificación
- `xcodebuild ... test` verde **3×** (sin flakiness; U6 toca estado global).
- Release build (`-configuration Release`) sin warnings de StrictConcurrency.
- `swiftlint` 0 violaciones. Swift 6.2 warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)